### PR TITLE
Include response chunking info in nonce

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,19 +28,23 @@ fmt: $(GOBIN)/goimports
 
 # Can be used to change the number of tests run, defaults to 1 to prevent caching
 TESTCOUNT = 1
-# Can be used to change the verobosity of tests: make test TESTVERBOSE=-v
-TESTVERBOSE =
-# Can be used to generate coverage reports for a specific package
-COVERPKG = $(PACKAGE)
+# Can be used to add flags to the go test invocation: make test TESTFLAGS=-v
+TESTFLAGS =
 # Can be used to change which package gets tested, defaults to all packages.
 TESTPKG = ./...
 
-test: $(COVERAGE)
-$(COVERAGE):
-	@mkdir -p $(@D)
-	go test -race -coverprofile=$(COVERAGE) -coverpkg=$(COVERPKG)/... -count=$(TESTCOUNT) $(TESTVERBOSE) $(TESTPKG)
+test:
+	go test -race -count=$(TESTCOUNT) $(TESTFLAGS) $(TESTPKG)
+
+# Can be used to generate coverage reports for a specific package
+COVERPKG = $(PACKAGE)
+
+.PHONY: $(COVERAGE)
 
 coverage: $(COVERAGE)
+$(COVERAGE):
+	@mkdir -p $(@D)
+	$(MAKE) test TESTFLAGS='-coverprofile=$(COVERAGE) -coverpkg=$(COVERPKG)/...'
 	go tool cover -html=$(COVERAGE)
 
 profile_cache:

--- a/ads/ads.go
+++ b/ads/ads.go
@@ -260,8 +260,8 @@ func LookupStreamTypeByRPCMethod(rpcMethod string) (StreamType, bool) {
 }
 
 var (
-	invalidNonceEncodingErr = errors.New("nonce isn't in hex encoding")
-	invalidNonceLengthErr   = errors.New("decoded nonce did not have expected length")
+	errInvalidNonceEncoding = errors.New("nonce isn't in hex encoding")
+	errInvalidNonceLength   = errors.New("decoded nonce did not have expected length")
 )
 
 // ParseRemainingChunksFromNonce checks whether the Diderot server implementation chunked the delta
@@ -276,11 +276,11 @@ var (
 func ParseRemainingChunksFromNonce(nonce string) (remainingChunks int, err error) {
 	decoded, err := hex.DecodeString(nonce)
 	if err != nil {
-		return 0, invalidNonceEncodingErr
+		return 0, errInvalidNonceEncoding
 	}
 
 	if len(decoded) != 12 {
-		return 0, invalidNonceLengthErr
+		return 0, errInvalidNonceLength
 	}
 
 	return int(binary.BigEndian.Uint32(decoded[8:12])), nil

--- a/ads/ads.go
+++ b/ads/ads.go
@@ -7,6 +7,7 @@ package ads
 import (
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"log/slog"
 	"sync"
 	"time"
@@ -258,23 +259,29 @@ func LookupStreamTypeByRPCMethod(rpcMethod string) (StreamType, bool) {
 	}
 }
 
+var (
+	invalidNonceEncodingErr = errors.New("nonce isn't in hex encoding")
+	invalidNonceLengthErr   = errors.New("decoded nonce did not have expected length")
+)
+
 // ParseRemainingChunksFromNonce checks whether the Diderot server implementation chunked the delta
 // responses because not all resources could fit in the same response without going over the default
 // max gRPC message size of 4MB. A nonce from Diderot always starts with the 64-bit nanosecond
 // timestamp of when the response was generated on the server. Then the number of remaining chunks as
 // a 32-bit integer. The sequence of integers is binary encoded with [binary.BigEndian] then hex
-// encoded. If the given nonce does not match the expected format, this function simply returns 0, as
-// it means the nonce was not created by Diderot server implementation, and therefore does not
-// contain the expected information.
-func ParseRemainingChunksFromNonce(nonce string) (remainingChunks int) {
+// encoded. If the given nonce does not match the expected format, this function simply returns 0
+// along with an error describing why it does not match. If the error isn't nil, it means the nonce
+// was not created by a Diderot server implementation, and therefore does not contain the expected
+// information.
+func ParseRemainingChunksFromNonce(nonce string) (remainingChunks int, err error) {
 	decoded, err := hex.DecodeString(nonce)
 	if err != nil {
-		return 0
+		return 0, invalidNonceEncodingErr
 	}
 
 	if len(decoded) != 12 {
-		return 0
+		return 0, invalidNonceLengthErr
 	}
 
-	return int(binary.BigEndian.Uint32(decoded[8:12]))
+	return int(binary.BigEndian.Uint32(decoded[8:12])), nil
 }

--- a/ads/ads_example_test.go
+++ b/ads/ads_example_test.go
@@ -1,0 +1,27 @@
+package ads_test
+
+import (
+	"log"
+
+	"github.com/linkedin/diderot/ads"
+)
+
+func ExampleParseRemainingChunksFromNonce() {
+	// Acquire a delta ADS client
+	var client ads.DeltaClient
+
+	var responses []*ads.DeltaDiscoveryResponse
+	for {
+		res, err := client.Recv()
+		if err != nil {
+			log.Panicf("Error receiving delta response: %v", err)
+		}
+		responses = append(responses, res)
+
+		if ads.ParseRemainingChunksFromNonce(res.Nonce) == 0 {
+			break
+		}
+	}
+
+	log.Printf("All responses received: %+v", responses)
+}

--- a/ads/ads_example_test.go
+++ b/ads/ads_example_test.go
@@ -18,7 +18,7 @@ func ExampleParseRemainingChunksFromNonce() {
 		}
 		responses = append(responses, res)
 
-		if ads.ParseRemainingChunksFromNonce(res.Nonce) == 0 {
+		if remaining, _ := ads.ParseRemainingChunksFromNonce(res.Nonce); remaining == 0 {
 			break
 		}
 	}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -324,7 +324,7 @@ func newSotWHandler(
 
 			res := &ads.SotWDiscoveryResponse{
 				TypeUrl: typeUrl,
-				Nonce:   utils.NewNonce(),
+				Nonce:   utils.NewNonce(0),
 			}
 			for _, e := range entries {
 				res.Resources = append(res.Resources, e.Resource.Resource)
@@ -349,7 +349,7 @@ func newSotWHandler(
 
 			res := &ads.SotWDiscoveryResponse{
 				TypeUrl: typeUrl,
-				Nonce:   utils.NewNonce(),
+				Nonce:   utils.NewNonce(0),
 			}
 			for _, r := range allResources {
 				res.Resources = append(res.Resources, r.Resource.Resource)

--- a/internal/server/handlers_delta.go
+++ b/internal/server/handlers_delta.go
@@ -92,7 +92,7 @@ type deltaSender struct {
 	queuedUpdates []queuedResourceUpdate
 	// The minimum size an encoded chunk will serialize to, in bytes. Used to check whether a given
 	// update can _ever_ be sent, and as the initial size of a chunk. Note that this value only depends
-	// on utils.MaxNonceLength and the length of typeURL.
+	// on utils.NonceLength and the length of typeURL.
 	minChunkSize int
 }
 

--- a/internal/server/handlers_delta.go
+++ b/internal/server/handlers_delta.go
@@ -92,7 +92,7 @@ type deltaSender struct {
 	queuedUpdates []queuedResourceUpdate
 	// The minimum size an encoded chunk will serialize to, in bytes. Used to check whether a given
 	// update can _ever_ be sent, and as the initial size of a chunk. Note that this value only depends
-	// on utils.NonceLength and the length of typeURL.
+	// on utils.MaxNonceLength and the length of typeURL.
 	minChunkSize int
 }
 
@@ -174,6 +174,11 @@ func (ds *deltaSender) chunk(resourceUpdates map[string]entry) (chunks []*ads.De
 			"typeURL", ds.typeURL,
 			"updates", len(ds.queuedUpdates),
 		)
+		for i, c := range chunks {
+			c.Nonce = utils.NewNonce(len(chunks) - i - 1)
+		}
+	} else {
+		chunks[0].Nonce = utils.NewNonce(0)
 	}
 
 	return chunks
@@ -182,7 +187,6 @@ func (ds *deltaSender) chunk(resourceUpdates map[string]entry) (chunks []*ads.De
 func (ds *deltaSender) newChunk() *ads.DeltaDiscoveryResponse {
 	return &ads.DeltaDiscoveryResponse{
 		TypeUrl: ds.typeURL,
-		Nonce:   utils.NewNonce(),
 	}
 }
 

--- a/internal/server/handlers_delta_test.go
+++ b/internal/server/handlers_delta_test.go
@@ -127,7 +127,9 @@ func TestDeltaHandlerChunking(t *testing.T) {
 		require.Len(t, responses, expectedChunks)
 		expectedRemainingChunks := 0
 		for _, res := range slices.Backward(responses) {
-			require.Equal(t, expectedRemainingChunks, ads.ParseRemainingChunksFromNonce(res.Nonce))
+			remaining, err := ads.ParseRemainingChunksFromNonce(res.Nonce)
+			require.NoError(t, err)
+			require.Equal(t, expectedRemainingChunks, remaining)
 			expectedRemainingChunks++
 		}
 		return responses

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -54,14 +54,19 @@ func TestNewNonce(t *testing.T) {
 		for _, expected := range []int{0, 42} {
 			nonce := newNonce(now, expected)
 			require.Equal(t, fmt.Sprintf("%x%08x", now.UnixNano(), expected), nonce)
-			actualRemainingChunks := ads.ParseRemainingChunksFromNonce(nonce)
+			actualRemainingChunks, err := ads.ParseRemainingChunksFromNonce(nonce)
+			require.NoError(t, err)
 			require.Equal(t, expected, actualRemainingChunks)
 		}
 	})
 	t.Run("badNonce", func(t *testing.T) {
-		require.Zero(t, ads.ParseRemainingChunksFromNonce("foo"))
+		remaining, err := ads.ParseRemainingChunksFromNonce("foo")
+		require.Error(t, err)
+		require.Zero(t, remaining)
 	})
 	t.Run("oldNonce", func(t *testing.T) {
-		require.Zero(t, ads.ParseRemainingChunksFromNonce(fmt.Sprintf("%x", now.UnixNano())))
+		remaining, err := ads.ParseRemainingChunksFromNonce(fmt.Sprintf("%x", now.UnixNano()))
+		require.Error(t, err)
+		require.Zero(t, remaining)
 	})
 }

--- a/server.go
+++ b/server.go
@@ -210,7 +210,7 @@ func (s *ADSServer) StreamAggregatedResources(stream ads.SotWStream) (err error)
 			return &ads.SotWDiscoveryResponse{
 				Resources: nil,
 				TypeUrl:   req.TypeUrl,
-				Nonce:     utils.NewNonce(),
+				Nonce:     utils.NewNonce(0),
 			}
 		},
 		setControlPlane: func(res *ads.SotWDiscoveryResponse, controlPlane *corev3.ControlPlane) {
@@ -251,7 +251,7 @@ func (s *ADSServer) DeltaAggregatedResources(stream ads.DeltaStream) (err error)
 			return &ads.DeltaDiscoveryResponse{
 				TypeUrl:          req.GetTypeUrl(),
 				RemovedResources: req.GetResourceNamesSubscribe(),
-				Nonce:            utils.NewNonce(),
+				Nonce:            utils.NewNonce(0),
 				ControlPlane:     s.controlPlane,
 			}
 		},


### PR DESCRIPTION
If a given delta response contains too many resources, the server will break it up into multiple responses. However, this means the client does not know whether it received all the resources for its subscription. This is especially relevant for wildcard subscriptions, for which the client does not know the resources ahead of time and therefore cannot wait for them explicitly. By returning additional metadata in the nonce (there is no field for this in the delta discovery response, though I'm hoping that will change https://github.com/cncf/xds/issues/99), the client can know if the server chunked the response, and react accordingly.