### PR TITLE
Print test coverage at the end of tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 .vscode/
 *.prof
 .cov
+out/

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,8 @@ COVERPKG = .
 
 test:
 	go test -race -coverprofile=$(COVERAGE) -coverpkg=$(COVERPKG)/... -count=$(TESTCOUNT) $(TESTFLAGS) $(TESTPKG)
-	go tool cover -func out/diderot.cov | awk '/total:/{print "Coverage: "$$3}'
+	@mkdir -p $(dir $(COVERAGE))
+	go tool cover -func $(COVERAGE) | awk '/total:/{print "Coverage: "$$3}'
 
 .PHONY: $(COVERAGE)
 

--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,12 @@ TESTCOUNT = 1
 TESTFLAGS =
 # Can be used to change which package gets tested, defaults to all packages.
 TESTPKG = ./...
+# Can be used to generate coverage reports for a specific package
+COVERPKG = .
 
 test:
-	go test -race -count=$(TESTCOUNT) $(TESTFLAGS) $(TESTPKG)
-
-# Can be used to generate coverage reports for a specific package
-COVERPKG = $(PACKAGE)
+	go test -race -coverprofile=$(COVERAGE) -coverpkg=$(COVERPKG)/... -count=$(TESTCOUNT) $(TESTFLAGS) $(TESTPKG)
+	go tool cover -func out/diderot.cov | awk '/total:/{print "Coverage: "$$3}'
 
 .PHONY: $(COVERAGE)
 

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ TESTPKG = ./...
 COVERPKG = .
 
 test:
-	go test -race -coverprofile=$(COVERAGE) -coverpkg=$(COVERPKG)/... -count=$(TESTCOUNT) $(TESTFLAGS) $(TESTPKG)
 	@mkdir -p $(dir $(COVERAGE))
+	go test -race -coverprofile=$(COVERAGE) -coverpkg=$(COVERPKG)/... -count=$(TESTCOUNT) $(TESTFLAGS) $(TESTPKG)
 	go tool cover -func $(COVERAGE) | awk '/total:/{print "Coverage: "$$3}'
 
 .PHONY: $(COVERAGE)


### PR DESCRIPTION
This way the coverage can be tracked as it evolves over time. Here's what the output looks like:
```
go test -race -coverprofile=/home/runner/work/diderot/diderot/out/diderot.cov -coverpkg=./... -count=1  ./...
	github.com/linkedin/diderot/examples/quickstart		coverage: 0.0% of statements
	github.com/linkedin/diderot/stats/server		ok  	github.com/linkedin/diderot	2.743s	coverage: 82.9% of statements in ./...
ok  	github.com/linkedin/diderot/ads	1.03[5](https://github.com/linkedin/diderot/actions/runs/13001532717/job/36261005203#step:6:6)s	coverage: 3.6% of statements in ./...
ok  	github.com/linkedin/diderot/internal/cache	1.028s	coverage: 3.0% of statements in ./...
ok  	github.com/linkedin/diderot/internal/server	[6](https://github.com/linkedin/diderot/actions/runs/13001532717/job/36261005203#step:6:7).565s	coverage: 19.4% of statements in ./...
ok  	github.com/linkedin/diderot/internal/utils	1.035s	coverage: 4.9% of statements in ./...
ok  	github.com/linkedin/diderot/testutils	1.041s	coverage: 4.4% of statements in ./...
go tool cover -func /home/runner/work/diderot/diderot/out/diderot.cov | awk '/total:/{print "Coverage: "$3}'
Coverage: 87.7%
```