### PR TITLE
Remove explicit handling of unsupported resource types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GOBIN = $(shell go env GOPATH)/bin
 all: fmt build
 
 build:
-	go build -v ./...
+	go build -tags=examples -v ./...
 	go test -v -c -o /dev/null $$(go list -f '{{if .TestGoFiles}}{{.ImportPath}}{{end}}' ./...)
 
 tidy:

--- a/doc.go
+++ b/doc.go
@@ -9,11 +9,11 @@ provides two core elements:
 The [ADSServer] is an implementation of the xDS protocol's various features. It implements both the
 Delta and state-of-the-world variants, but abstracts this away completely by only exposing a single
 entry point: the [ResourceLocator]. When the server receives a request (be it Delta or SotW), it
-will first check if the requested type is supported, whether it is an ACK (or a NACK), then invoke,
-if necessary, the corresponding subscription methods on the ResourceLocator. The locator is simply
-in charge of invoking Notify on the handler whenever the resource changes, and the server will relay
-that resource update to the client using the corresponding response type. This makes it very easy to
-implement an xDS control plane without needing to worry about the finer details of the xDS protocol.
+will check whether it is an ACK (or a NACK), then invoke the corresponding subscription methods on
+the [ResourceLocator]. The locator is simply in charge of invoking Notify on the handler whenever
+the resource changes, and the server will relay that resource update to the client using the
+corresponding response type. This makes it very easy to implement an xDS control plane without
+needing to worry about the finer details of the xDS protocol.
 
 Most ResourceLocator implementations will likely be a series of [Cache] instances for the
 corresponding supported types, which implements the semantics of Subscribe and Resubscribe out of

--- a/internal/server/subscription_manager.go
+++ b/internal/server/subscription_manager.go
@@ -16,11 +16,6 @@ type ResourceLocator interface {
 		typeURL, resourceName string,
 		handler ads.RawSubscriptionHandler,
 	) (unsubscribe func())
-	Resubscribe(
-		streamCtx context.Context,
-		typeURL, resourceName string,
-		handler ads.RawSubscriptionHandler,
-	)
 }
 
 type SubscriptionManager[REQ proto.Message] interface {
@@ -200,12 +195,11 @@ func (c *subscriptionManagerCore) UnsubscribeAll() {
 }
 
 func (c *subscriptionManagerCore) subscribe(name string) {
-	_, ok := c.subscriptions[name]
-	if !ok {
-		c.subscriptions[name] = c.locator.Subscribe(c.ctx, c.typeURL, name, c.handler)
-	} else {
-		c.locator.Resubscribe(c.ctx, c.typeURL, name, c.handler)
+	unsub, ok := c.subscriptions[name]
+	if ok {
+		unsub()
 	}
+	c.subscriptions[name] = c.locator.Subscribe(c.ctx, c.typeURL, name, c.handler)
 }
 
 func (c *subscriptionManagerCore) unsubscribe(name string) {

--- a/internal/server/subscription_manager.go
+++ b/internal/server/subscription_manager.go
@@ -195,10 +195,7 @@ func (c *subscriptionManagerCore) UnsubscribeAll() {
 }
 
 func (c *subscriptionManagerCore) subscribe(name string) {
-	unsub, ok := c.subscriptions[name]
-	if ok {
-		unsub()
-	}
+	c.unsubscribe(name)
 	c.subscriptions[name] = c.locator.Subscribe(c.ctx, c.typeURL, name, c.handler)
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -25,19 +25,15 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/xds"
 	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 var (
-	badTypeURL   = "foobar"
-	badResources = []string{"badResource1", "badResource2"}
 	controlPlane = &core.ControlPlane{Identifier: "fooBar"}
 )
 
 type serverStatsHandler struct {
-	UnknownTypes     atomic.Int64
 	UnknownResources atomic.Int64
 	NACKsReceived    atomic.Int64
 	ACKsReceived     atomic.Int64
@@ -52,9 +48,6 @@ func (m *serverStatsHandler) HandleServerEvent(ctx context.Context, event server
 		if e.IsACK {
 			m.ACKsReceived.Add(1)
 		}
-		if e.IsRequestedTypeUnknown {
-			m.UnknownTypes.Add(1)
-		}
 	case *serverstats.ResourceQueued:
 		if !e.ResourceExists {
 			m.UnknownResources.Add(1)
@@ -63,7 +56,6 @@ func (m *serverStatsHandler) HandleServerEvent(ctx context.Context, event server
 }
 
 func (m *serverStatsHandler) reset() {
-	m.UnknownTypes.Store(0)
 	m.UnknownResources.Store(0)
 	m.NACKsReceived.Store(0)
 	m.ACKsReceived.Store(0)
@@ -85,12 +77,6 @@ func (tl *testLocator) checkContextNode(streamCtx context.Context) {
 	testutils.ProtoEquals(tl.t, tl.node, node)
 }
 
-func (tl *testLocator) IsTypeSupported(streamCtx context.Context, typeURL string) bool {
-	tl.checkContextNode(streamCtx)
-	_, ok := tl.caches[typeURL]
-	return ok
-}
-
 func (tl *testLocator) Subscribe(
 	streamCtx context.Context,
 	typeURL, resourceName string,
@@ -103,15 +89,6 @@ func (tl *testLocator) Subscribe(
 	return func() {
 		Unsubscribe(c, resourceName, handler)
 	}
-}
-
-func (tl *testLocator) Resubscribe(
-	streamCtx context.Context,
-	typeURL, resourceName string,
-	handler ads.RawSubscriptionHandler,
-) {
-	tl.checkContextNode(streamCtx)
-	Subscribe(tl.caches[typeURL], resourceName, handler)
 }
 
 func newTestLocator(t *testing.T, node *ads.Node, types ...Type) *testLocator {
@@ -330,18 +307,6 @@ func TestEndToEnd(t *testing.T) {
 		require.Eventually(t, func() bool {
 			return statsHandler.NACKsReceived.Load() == 1
 		}, 2*time.Second, 100*time.Millisecond)
-
-		require.NoError(t, stream.Send(&ads.DeltaDiscoveryRequest{
-			Node:                   new(core.Node),
-			TypeUrl:                badTypeURL,
-			ResourceNamesSubscribe: badResources,
-		}))
-
-		waitForResponse(t, res, stream, 10*time.Millisecond)
-
-		require.Equal(t, badTypeURL, res.GetTypeUrl())
-		require.Equal(t, badResources, res.GetRemovedResources())
-		require.Equal(t, int64(1), statsHandler.UnknownTypes.Load())
 	})
 
 	t.Run("SotW", func(t *testing.T) {
@@ -436,18 +401,6 @@ func TestEndToEnd(t *testing.T) {
 		require.Eventually(t, func() bool {
 			return statsHandler.NACKsReceived.Load() == 1
 		}, 2*time.Second, 100*time.Millisecond)
-
-		require.NoError(t, stream.Send(&ads.SotWDiscoveryRequest{
-			Node:          new(core.Node),
-			TypeUrl:       badTypeURL,
-			ResourceNames: badResources,
-		}))
-
-		waitForResponse(t, res, stream, 10*time.Millisecond)
-
-		require.Equal(t, badTypeURL, res.GetTypeUrl())
-		require.Empty(t, res.GetResources())
-		require.Equal(t, int64(1), statsHandler.UnknownTypes.Load())
 	})
 
 	// Author's note: there are no semantic differences in the way subscriptions and ACKs are managed for
@@ -487,21 +440,6 @@ func TestEndToEnd(t *testing.T) {
 		require.WithinDuration(t, time.Now(), startWait.Add(wait), delta)
 		require.Len(t, res.Resources, 1)
 		testutils.ProtoEquals(t, testutils.MustMarshal(t, testResource).Resource, res.Resources[0])
-
-		// Note that the following is technically a protocol violation. As noted above, PseudoDeltaSotW
-		// cannot signal to the client that a resource does not exist, it simply never responds. However, in
-		// the event that the server receives a request for a type it does not know (and never will since
-		// they are not dynamic and determined at startup), since there is no way to signal that this request
-		// will never be satisfied, the server will respond with an empty response.
-		require.NoError(t, stream.Send(&ads.SotWDiscoveryRequest{
-			Node:          new(core.Node),
-			TypeUrl:       badTypeURL,
-			ResourceNames: badResources,
-		}))
-		waitForResponse(t, res, stream, wait+delta)
-		require.Equal(t, badTypeURL, res.GetTypeUrl(), prototext.Format(res))
-		require.Empty(t, res.GetResources())
-		require.Equal(t, int64(1), statsHandler.UnknownTypes.Load())
 	})
 
 }
@@ -712,22 +650,10 @@ func TestSubscriptionManagerSubscriptions(t *testing.T) {
 	}
 }
 
-type mockResourceLocator struct {
-	isTypeSupported func(typeURL string) bool
-	subscribe       func(typeURL, resourceName string) func()
-	resubscribe     func(typeURL, resourceName string)
-}
+type mockResourceLocator func(typeURL, resourceName string) func()
 
-func (m *mockResourceLocator) IsTypeSupported(_ context.Context, typeURL string) bool {
-	return m.isTypeSupported(typeURL)
-}
-
-func (m *mockResourceLocator) Subscribe(_ context.Context, typeURL, resourceName string, _ ads.RawSubscriptionHandler) func() {
-	return m.subscribe(typeURL, resourceName)
-}
-
-func (m *mockResourceLocator) Resubscribe(_ context.Context, typeURL, resourceName string, _ ads.RawSubscriptionHandler) {
-	m.resubscribe(typeURL, resourceName)
+func (m mockResourceLocator) Subscribe(_ context.Context, typeURL, resourceName string, _ ads.RawSubscriptionHandler) func() {
+	return m(typeURL, resourceName)
 }
 
 func TestImplicitWildcardSubscription(t *testing.T) {
@@ -735,44 +661,28 @@ func TestImplicitWildcardSubscription(t *testing.T) {
 	h := NewNoopBatchSubscriptionHandler(t)
 	typeURL := TypeOf[*ads.Secret]().URL()
 
-	newMockLocator := func(t *testing.T) (l *mockResourceLocator, wildcardSub, fooSub chan struct{}) {
+	newMockLocator := func(t *testing.T) (rs mockResourceLocator, wildcardSub, fooSub chan struct{}) {
 		wildcardSub = make(chan struct{}, 1)
 		fooSub = make(chan struct{}, 1)
-		l = &mockResourceLocator{
-			isTypeSupported: func(actualTypeURL string) bool {
-				require.Equal(t, typeURL, actualTypeURL)
-				return true
-			},
-			subscribe: func(actualTypeURL, resourceName string) func() {
-				require.Equal(t, typeURL, actualTypeURL)
-				switch resourceName {
-				case ads.WildcardSubscription:
-					wildcardSub <- struct{}{}
-					return func() {
-						close(wildcardSub)
-					}
-				case foo:
-					fooSub <- struct{}{}
-					return func() {
-						close(fooSub)
-					}
-				default:
-					t.Fatalf("Unexpected resource name %q", resourceName)
-					return nil
+		rs = func(actualTypeURL, resourceName string) func() {
+			require.Equal(t, typeURL, actualTypeURL)
+			switch resourceName {
+			case ads.WildcardSubscription:
+				wildcardSub <- struct{}{}
+				return func() {
+					close(wildcardSub)
 				}
-			},
-			resubscribe: func(actualTypeURL, resourceName string) {
-				switch resourceName {
-				case ads.WildcardSubscription:
-					wildcardSub <- struct{}{}
-				case foo:
-					fooSub <- struct{}{}
-				default:
-					t.Fatalf("Unexpected resource name %q", resourceName)
+			case foo:
+				fooSub <- struct{}{}
+				return func() {
+					close(fooSub)
 				}
-			},
+			default:
+				t.Fatalf("Unexpected resource name %q", resourceName)
+				return nil
+			}
 		}
-		return l, wildcardSub, fooSub
+		return rs, wildcardSub, fooSub
 	}
 	requireSelect := func(t *testing.T, ch <-chan struct{}, shouldBeClosed bool) {
 		t.Helper()
@@ -933,15 +843,12 @@ func TestSubscriptionManagerUnsubscribeAll(t *testing.T) {
 
 		var wg sync.WaitGroup
 
-		l := &mockResourceLocator{
-			isTypeSupported: func(string) bool { return true },
-			subscribe: func(_, resourceName string) func() {
+		l := mockResourceLocator(func(_, resourceName string) func() {
+			wg.Done()
+			return func() {
 				wg.Done()
-				return func() {
-					wg.Done()
-				}
-			},
-		}
+			}
+		})
 
 		m := internal.NewDeltaSubscriptionManager(context.Background(), l, typeURL, h)
 
@@ -959,15 +866,12 @@ func TestSubscriptionManagerUnsubscribeAll(t *testing.T) {
 	t.Run("on context expiry", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		var wg sync.WaitGroup
-		l := &mockResourceLocator{
-			isTypeSupported: func(string) bool { return true },
-			subscribe: func(_, _ string) func() {
+		l := mockResourceLocator(func(_, _ string) func() {
+			wg.Done()
+			return func() {
 				wg.Done()
-				return func() {
-					wg.Done()
-				}
-			},
-		}
+			}
+		})
 		m := internal.NewDeltaSubscriptionManager(ctx, l, typeURL, h)
 
 		wg.Add(1)

--- a/server_test.go
+++ b/server_test.go
@@ -661,10 +661,10 @@ func TestImplicitWildcardSubscription(t *testing.T) {
 	h := NewNoopBatchSubscriptionHandler(t)
 	typeURL := TypeOf[*ads.Secret]().URL()
 
-	newMockLocator := func(t *testing.T) (rs mockResourceLocator, wildcardSub, fooSub chan struct{}) {
+	newMockLocator := func(t *testing.T) (l mockResourceLocator, wildcardSub, fooSub chan struct{}) {
 		wildcardSub = make(chan struct{}, 1)
 		fooSub = make(chan struct{}, 1)
-		rs = func(actualTypeURL, resourceName string) func() {
+		l = func(actualTypeURL, resourceName string) func() {
 			require.Equal(t, typeURL, actualTypeURL)
 			switch resourceName {
 			case ads.WildcardSubscription:
@@ -682,7 +682,7 @@ func TestImplicitWildcardSubscription(t *testing.T) {
 				return nil
 			}
 		}
-		return rs, wildcardSub, fooSub
+		return l, wildcardSub, fooSub
 	}
 	requireSelect := func(t *testing.T, ch <-chan struct{}, shouldBeClosed bool) {
 		t.Helper()

--- a/stats/server/server_stats.go
+++ b/stats/server/server_stats.go
@@ -22,8 +22,6 @@ type Event interface {
 type RequestReceived struct {
 	// The received request, either [ads.SotWDiscoveryRequest] or [ads.DeltaDiscoveryRequest].
 	Req proto.Message
-	// True if the client requested a type that is not supported, determined by the ResourceLocator.
-	IsRequestedTypeUnknown bool
 	// Whether the request is an ACK
 	IsACK bool
 	// Whether the request is a NACK. Note that this is an important stat that requires immediate human


### PR DESCRIPTION
Because there is no explicit provision for unknown resource types in the xDS protocol, the server implementation had to make a bunch of assumptions about how it should respond. These assumptions incidentally violated the xDS protocol NACK/ACK flow. Instead, the behavior should be handed off to the `ResourceLocator` implementation so that it can decide what to do. This also allows the simplification of the `ResourceLocator` interface, which is an added benefit.

Note that this change is backwards incompatible, so will need to be bumped carefully.

I have tested this manually using the bad version of rest.li which triggered this loop (https://github.com/linkedin/rest.li/pull/1038), and can confirm that this behavior is fixed.