### PR TITLE
Use an interceptor during test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ COVERPKG = .
 
 test:
 	@mkdir -p $(dir $(COVERAGE))
-	go test -race -coverprofile=$(COVERAGE) -coverpkg=$(COVERPKG)/... -count=$(TESTCOUNT) $(TESTFLAGS) $(TESTPKG)
+	go test -v -race -coverprofile=$(COVERAGE) -coverpkg=$(COVERPKG)/... -count=$(TESTCOUNT) $(TESTFLAGS) $(TESTPKG)
 	go tool cover -func $(COVERAGE) | awk '/total:/{print "Coverage: "$$3}'
 
 .PHONY: $(COVERAGE)
@@ -45,7 +45,7 @@ test:
 coverage: $(COVERAGE)
 $(COVERAGE):
 	@mkdir -p $(@D)
-	$(MAKE) test TESTFLAGS='-coverprofile=$(COVERAGE) -coverpkg=$(COVERPKG)/...'
+	-$(MAKE) test
 	go tool cover -html=$(COVERAGE)
 
 profile_cache:

--- a/server_test.go
+++ b/server_test.go
@@ -201,6 +201,9 @@ func TestEndToEnd(t *testing.T) {
 		grpc.WithResolvers(xdsResolverBuilder),
 	)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := discovery.NewAggregatedDiscoveryServiceClient(conn)
 	t.Run("xDS sanity check", func(t *testing.T) {


### PR DESCRIPTION
Otherwise, the stream is partially initialized during the test, which triggers a race condition when checking which requests the ADS client is sending. Tested by running `make test TESTCOUNT=100` to see if the issue occurs again.