### PR TITLE
Ensure map is always returned to pool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,13 @@ TESTFLAGS =
 TESTPKG = ./...
 # Can be used to generate coverage reports for a specific package
 COVERPKG = .
+# The default coverage flags. Specifying COVERFLAGS= disables coverage, which meakes the tests run
+# faster.
+COVERFLAGS = -coverprofile=$(COVERAGE) -coverpkg=$(COVERPKG)/...
 
 test:
 	@mkdir -p $(dir $(COVERAGE))
-	go test -v -race -coverprofile=$(COVERAGE) -coverpkg=$(COVERPKG)/... -count=$(TESTCOUNT) $(TESTFLAGS) $(TESTPKG)
+	go test -v -race $(COVERFLAGS) -count=$(TESTCOUNT) $(TESTFLAGS) $(TESTPKG)
 	go tool cover -func $(COVERAGE) | awk '/total:/{print "Coverage: "$$3}'
 
 .PHONY: $(COVERAGE)

--- a/internal/server/handlers_bench_test.go
+++ b/internal/server/handlers_bench_test.go
@@ -28,9 +28,9 @@ func benchmarkHandlers(tb testing.TB, count, subscriptions int) {
 		NoopLimiter{},
 		new(customStatsHandler),
 		false,
-		func(resources map[string]entry) error {
+		func(resources map[string]*ads.RawResource) error {
 			for _, r := range resources {
-				if r.Resource.Version == finalVersion {
+				if r.Version == finalVersion {
 					finished.Done()
 				}
 			}

--- a/internal/server/handlers_delta_test.go
+++ b/internal/server/handlers_delta_test.go
@@ -122,7 +122,7 @@ func TestDeltaHandlerChunking(t *testing.T) {
 		minChunkSize: initialChunkSize(typeURL),
 	}
 
-	getSentResponses := func(resources map[string]entry, expectedChunks int) []*ads.DeltaDiscoveryResponse {
+	getSentResponses := func(resources map[string]*ads.RawResource, expectedChunks int) []*ads.DeltaDiscoveryResponse {
 		responses := ds.chunk(resources)
 		require.Len(t, responses, expectedChunks)
 		expectedRemainingChunks := 0
@@ -135,9 +135,9 @@ func TestDeltaHandlerChunking(t *testing.T) {
 		return responses
 	}
 
-	sentResponses := getSentResponses(map[string]entry{
-		foo.Name: {Resource: foo},
-		bar.Name: {Resource: bar},
+	sentResponses := getSentResponses(map[string]*ads.RawResource{
+		foo.Name: foo,
+		bar.Name: bar,
 	}, 2)
 	require.Equal(t, len(sentResponses[0].Resources), 1)
 	require.Equal(t, len(sentResponses[1].Resources), 1)
@@ -155,9 +155,9 @@ func TestDeltaHandlerChunking(t *testing.T) {
 	// Delete resources whose names are the same size as the resources to trip the chunker with the same conditions
 	name1 := strings.Repeat("1", resourceSize)
 	name2 := strings.Repeat("2", resourceSize)
-	sentResponses = getSentResponses(map[string]entry{
-		name1: {Resource: nil},
-		name2: {Resource: nil},
+	sentResponses = getSentResponses(map[string]*ads.RawResource{
+		name1: nil,
+		name2: nil,
 	}, 2)
 	require.Equal(t, len(sentResponses[0].RemovedResources), 1)
 	require.Equal(t, len(sentResponses[1].RemovedResources), 1)
@@ -169,11 +169,11 @@ func TestDeltaHandlerChunking(t *testing.T) {
 	small1, small2, small3 := "a", "b", "c"
 	wayTooBig := strings.Repeat("3", 10*resourceSize)
 
-	sentResponses = getSentResponses(map[string]entry{
-		small1:    {Resource: nil},
-		small2:    {Resource: nil},
-		small3:    {Resource: nil},
-		wayTooBig: {Resource: nil},
+	sentResponses = getSentResponses(map[string]*ads.RawResource{
+		small1:    nil,
+		small2:    nil,
+		small3:    nil,
+		wayTooBig: nil,
 	}, 1)
 	require.Equal(t, len(sentResponses[0].RemovedResources), 3)
 	require.ElementsMatch(t, []string{small1, small2, small3}, sentResponses[0].RemovedResources)


### PR DESCRIPTION
Without this, the `entries` map was not returned to pool when `send` returned an error. This ensures that the map is returned so that it can be reused. In addition, this refactors an unused type called `entry`, which just occupies memory and makes the code hard to work with.