### PR TITLE
Correctly handle deletion of cache entry

### DIFF
--- a/internal/cache/subscriber_set.go
+++ b/internal/cache/subscriber_set.go
@@ -104,6 +104,11 @@ func (m *SubscriberSet[T]) Size() int {
 	return int(m.size.Load())
 }
 
+// IsEmpty is a convenience function that checks whether the set is empty˜.
+func (m *SubscriberSet[T]) IsEmpty() bool {
+	return m.Size() == 0
+}
+
 type SubscriberSetIterator[T proto.Message] iter.Seq2[ads.SubscriptionHandler[T], time.Time]
 
 // Iterator returns an iterator over the SubscriberSet. The returned associated version can be used


### PR DESCRIPTION
See documentation in code for more details, but the high-level problem is that an entry was deleted too early from the cache, orphaning the notification loop. If the same resource gets re-created, it would create a new entry and execute a new notification loop. These two loops would then deliver competing notifiations to subscribers.