### PR TITLE
Use a the conn interface for testing the ADS client

### DIFF
--- a/ads/ads.go
+++ b/ads/ads.go
@@ -269,9 +269,9 @@ var StreamTypes = [...]StreamType{UnknownStreamType, DeltaStreamType, SotWStream
 // if it is neither.
 func LookupStreamTypeByRPCMethod(rpcMethod string) (StreamType, bool) {
 	switch rpcMethod {
-	case "/envoy.service.discovery.v3.AggregatedDiscoveryService/StreamAggregatedResources":
+	case discovery.AggregatedDiscoveryService_StreamAggregatedResources_FullMethodName:
 		return SotWStreamType, true
-	case "/envoy.service.discovery.v3.AggregatedDiscoveryService/DeltaAggregatedResources":
+	case discovery.AggregatedDiscoveryService_DeltaAggregatedResources_FullMethodName:
 		return DeltaStreamType, true
 	default:
 		return UnknownStreamType, false

--- a/client.go
+++ b/client.go
@@ -29,7 +29,7 @@ const (
 
 // NewADSClient creates a new [*ADSClient] with the given options. To stop the client, close the
 // backing [grpc.ClientConn].
-func NewADSClient(conn *grpc.ClientConn, node *ads.Node, opts ...ADSClientOption) *ADSClient {
+func NewADSClient(conn grpc.ClientConnInterface, node *ads.Node, opts ...ADSClientOption) *ADSClient {
 	c := &ADSClient{
 		conn:            conn,
 		node:            node,
@@ -81,7 +81,7 @@ func WithResponseChunkingSupported(supported bool) ADSClientOption {
 type ADSClient struct {
 	options
 	node *ads.Node
-	conn *grpc.ClientConn
+	conn grpc.ClientConnInterface
 
 	newSubscription chan struct{}
 

--- a/client_test.go
+++ b/client_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/linkedin/diderot/internal/utils"
 	"github.com/linkedin/diderot/testutils"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -359,7 +358,6 @@ func OnceWatcher[T proto.Message](m *map[string]*ads.Resource[T]) Watcher[T] {
 type mockConn struct {
 	t       *testing.T
 	streams chan *mockStream
-	group   errgroup.Group
 }
 
 func (mc *mockConn) Invoke(context.Context, string, any, any, ...grpc.CallOption) error {

--- a/client_test.go
+++ b/client_test.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -28,6 +29,20 @@ import (
 type Timestamp = timestamppb.Timestamp
 
 var Now = timestamppb.Now
+
+func newClient(t *testing.T, chunkingSupport bool) (conn *mockConn, client *ADSClient) {
+	conn = &mockConn{
+		t:       t,
+		streams: make(chan *mockStream),
+	}
+	client = NewADSClient(
+		conn,
+		&ads.Node{Id: "test"},
+		WithReconnectBackoff(0, 0),
+		WithResponseChunkingSupported(chunkingSupport),
+	)
+	return conn, client
+}
 
 func TestADSClient(t *testing.T) {
 	tests := []struct {
@@ -48,9 +63,8 @@ func TestADSClient(t *testing.T) {
 
 	// Check that the client NACKs a response for a type that was never subscribed to.
 	t.Run("invalid type", func(t *testing.T) {
-		ts, server := setUpTest(t)
+		conn, client := newClient(t, defaultResponseChunkingSupported)
 
-		client := NewADSClient(ts.Dial(), &ads.Node{Id: "test"})
 		Watch(client, ads.WildcardSubscription, &FuncWatcher[*Timestamp]{
 			notify: func(resources iter.Seq2[string, *ads.Resource[*Timestamp]]) error {
 				require.FailNow(t, "Should not be called")
@@ -58,72 +72,59 @@ func TestADSClient(t *testing.T) {
 			},
 		})
 
-		server.accept()
+		ms := conn.accept()
 
-		server.expectSubscriptions(ads.WildcardSubscription)
+		ms.expectSubscriptions(ads.WildcardSubscription)
 
-		nonce := respond[*durationpb.Duration](server, []*ads.Resource[*durationpb.Duration]{
+		nonce := respond[*durationpb.Duration](ms, []*ads.Resource[*durationpb.Duration]{
 			ads.NewResource[*durationpb.Duration]("test", "0", durationpb.New(time.Minute)),
 		}, nil, 0)
 
-		expectNACK[*durationpb.Duration](server, nonce, codes.InvalidArgument, utils.GetTypeURL[*durationpb.Duration]())
+		expectNACK[*durationpb.Duration](ms, nonce, codes.InvalidArgument, utils.GetTypeURL[*durationpb.Duration]())
 	})
 
 	// Check that the client NACKs a response if a watcher returns an error.
 	t.Run("NACKs", func(t *testing.T) {
-		ts, server := setUpTest(t)
+		conn, client := newClient(t, defaultResponseChunkingSupported)
 
-		client := NewADSClient(ts.Dial(), &ads.Node{Id: "test"})
 		Watch(client, ads.WildcardSubscription, &FuncWatcher[*Timestamp]{
 			notify: func(resources iter.Seq2[string, *ads.Resource[*Timestamp]]) error {
 				return io.EOF
 			},
 		})
 
-		server.accept()
+		ms := conn.accept()
 
-		server.expectSubscriptions(ads.WildcardSubscription)
+		ms.expectSubscriptions(ads.WildcardSubscription)
 
-		nonce := server.respondUpdates(0, ads.NewResource[*Timestamp]("foo", "0", Now()))
+		nonce := ms.respondUpdates(0, ads.NewResource[*Timestamp]("foo", "0", Now()))
 
-		expectNACK[*Timestamp](server, nonce, codes.InvalidArgument, io.EOF.Error())
+		expectNACK[*Timestamp](ms, nonce, codes.InvalidArgument, io.EOF.Error())
 	})
 
 	// Check that if the server responds with an unknown resource, it is skipped and reported, but other
 	// valid resources in the response are still parsed.
 	t.Run("unknown resource", func(t *testing.T) {
-		ts, server := setUpTest(t)
+		conn, client := newClient(t, defaultResponseChunkingSupported)
 
-		client := NewADSClient(ts.Dial(), &ads.Node{Id: "test"})
 		fooH := make(testutils.ChanSubscriptionHandler[*Timestamp], 1)
 		foo := ads.NewResource[*Timestamp]("foo", "0", Now())
 		Watch(client, foo.Name, ChanWatcher[*Timestamp](fooH))
 
-		server.accept()
+		ms := conn.accept()
 
-		server.expectSubscriptions(foo.Name)
+		ms.expectSubscriptions(foo.Name)
 
-		nonce := server.respondUpdates(0, foo, ads.NewResource("bar", "0", Now()))
+		nonce := ms.respondUpdates(0, foo, ads.NewResource("bar", "0", Now()))
 
-		expectNACK[*Timestamp](server, nonce, codes.InvalidArgument, "bar")
+		expectNACK[*Timestamp](ms, nonce, codes.InvalidArgument, "bar")
 		fooH.WaitForUpdate(t, foo)
 	})
 }
 
-func setUpTest(t *testing.T) (ts *testutils.TestServer, server *mockServer) {
-	server = newMockServer(t)
-
-	ts = testutils.NewTestGRPCServer(t, grpc.StreamInterceptor(server.interceptor()))
-
-	discovery.RegisterAggregatedDiscoveryServiceServer(ts.Server, server)
-	ts.Start()
-	return ts, server
-}
-
 func testADSClientFlow(t *testing.T, chunkingEnabled bool) {
-	ts, server := setUpTest(t)
+	conn, client := newClient(t, chunkingEnabled)
 
-	client := NewADSClient(ts.Dial(), &ads.Node{Id: "test"}, WithResponseChunkingSupported(chunkingEnabled))
 	fooH := make(testutils.ChanSubscriptionHandler[*Timestamp], 1)
 	foo := ads.NewResource[*Timestamp]("foo", "0", Now())
 	Watch(client, foo.Name, ChanWatcher[*Timestamp](fooH))
@@ -132,36 +133,36 @@ func testADSClientFlow(t *testing.T, chunkingEnabled bool) {
 	checkNoUpdate(t, fooH)
 
 	// Accept a new stream
-	closeStream := server.accept()
+	ms := conn.accept()
 
 	// The resource does not initially exist, the first update should be a deletion.
-	server.expectSubscriptions(foo.Name)
-	nonce := server.respondDeletes(0, foo.Name)
+	ms.expectSubscriptions(foo.Name)
+	nonce := ms.respondDeletes(0, foo.Name)
 	fooH.WaitForDelete(t, foo.Name)
-	server.expectACK(nonce)
+	ms.expectACK(nonce)
 
 	// Set foo, and wait for the creation update
-	nonce = server.respondUpdates(0, foo)
+	nonce = ms.respondUpdates(0, foo)
 	fooH.WaitForUpdate(t, foo)
-	server.expectACK(nonce)
+	ms.expectACK(nonce)
 
-	closeStream()
-	closeStream = server.accept()
+	ms.cancel()
+	ms = conn.accept()
 	// Closing and reopening the stream makes the client reconnect, but since foo hasn't changed, nothing
 	// should happen.
-	server.expectSubscriptions(foo.Name)
-	nonce = server.respondUpdates(0, foo)
+	ms.expectSubscriptions(foo.Name)
+	nonce = ms.respondUpdates(0, foo)
 	checkNoUpdate(t, fooH)
-	server.expectACK(nonce)
+	ms.expectACK(nonce)
 
 	// Disconnect the client, foo is updated during disconnect so expect a notification
-	closeStream()
+	ms.cancel()
 	foo = ads.NewResource(foo.Name, "1", Now())
-	closeStream = server.accept()
-	server.expectSubscriptions(foo.Name)
-	nonce = server.respondUpdates(0, foo)
+	ms = conn.accept()
+	ms.expectSubscriptions(foo.Name)
+	nonce = ms.respondUpdates(0, foo)
 	fooH.WaitForUpdate(t, foo)
-	server.expectACK(nonce)
+	ms.expectACK(nonce)
 
 	wildcardH := make(testutils.ChanSubscriptionHandler[*Timestamp], 2)
 	var wildcardExpectedCount atomic.Int32
@@ -178,23 +179,23 @@ func testADSClientFlow(t *testing.T, chunkingEnabled bool) {
 		},
 	})
 
-	server.expectSubscriptions(ads.WildcardSubscription)
+	ms.expectSubscriptions(ads.WildcardSubscription)
 	bar := ads.NewResource[*Timestamp]("bar", "0", Now())
 	if chunkingEnabled {
 		// Respond in multiple chunks, to test that those are handled correctly
-		chunkNonce1 := server.respondUpdates(1, foo)
+		chunkNonce1 := ms.respondUpdates(1, foo)
 		// No update expected after first chunk
 		checkNoUpdate(t, wildcardH)
 		// As soon as the second chunk arrives, an update is expected, so update the expected count before
 		// sending the response.
 		wildcardExpectedCount.Store(2)
-		chunkNonce2 := server.respondUpdates(0, bar)
-		server.expectACK(chunkNonce1)
-		server.expectACK(chunkNonce2)
+		chunkNonce2 := ms.respondUpdates(0, bar)
+		ms.expectACK(chunkNonce1)
+		ms.expectACK(chunkNonce2)
 	} else {
 		wildcardExpectedCount.Store(2)
-		nonce = server.respondUpdates(0, foo, bar)
-		server.expectACK(nonce)
+		nonce = ms.respondUpdates(0, foo, bar)
+		ms.expectACK(nonce)
 	}
 
 	// Expect a notification for foo and bar for wildcardH, but since fooH has already seen that version
@@ -207,8 +208,8 @@ func testADSClientFlow(t *testing.T, chunkingEnabled bool) {
 
 	// Clear foo, expect a deletion on fooH and the wildcard subscriber.
 	wildcardExpectedCount.Store(1)
-	nonce = server.respondDeletes(0, foo.Name)
-	server.expectACK(nonce)
+	nonce = ms.respondDeletes(0, foo.Name)
+	ms.expectACK(nonce)
 	fooH.WaitForDelete(t, foo.Name)
 	wildcardH.WaitForDelete(t, foo.Name)
 
@@ -216,13 +217,13 @@ func testADSClientFlow(t *testing.T, chunkingEnabled bool) {
 	wildcardExpectedCount.Store(1)
 	gcURL := ads.NewGlobCollectionURL[*Timestamp]("", "collection", nil)
 	fooGlob := ads.NewResource(gcURL.MemberURN("foo"), "0", Now())
-	nonce = server.respondUpdates(0, fooGlob)
-	server.expectACK(nonce)
+	nonce = ms.respondUpdates(0, fooGlob)
+	ms.expectACK(nonce)
 	wildcardH.WaitForNotifications(t, testutils.ExpectUpdate(fooGlob))
 
 	barGlob := ads.NewResource(gcURL.MemberURN("bar"), "0", Now())
-	nonce = server.respondUpdates(0, barGlob)
-	server.expectACK(nonce)
+	nonce = ms.respondUpdates(0, barGlob)
+	ms.expectACK(nonce)
 	wildcardH.WaitForNotifications(t, testutils.ExpectUpdate(barGlob))
 
 	// Subscribe to the glob collection. expecting an update for fooGlob and barGlob.
@@ -242,10 +243,10 @@ func testADSClientFlow(t *testing.T, chunkingEnabled bool) {
 			return nil
 		},
 	})
-	server.expectSubscriptions(gcURL.String())
+	ms.expectSubscriptions(gcURL.String())
 	globExpectedCount.Store(2)
-	nonce = server.respondUpdates(0, fooGlob, barGlob)
-	server.expectACK(nonce)
+	nonce = ms.respondUpdates(0, fooGlob, barGlob)
+	ms.expectACK(nonce)
 	globH.WaitForNotifications(t,
 		testutils.ExpectUpdate(fooGlob),
 		testutils.ExpectUpdate(barGlob),
@@ -255,8 +256,8 @@ func testADSClientFlow(t *testing.T, chunkingEnabled bool) {
 	// Clear fooGlob, expect deletions for it.
 	wildcardExpectedCount.Store(1)
 	globExpectedCount.Store(1)
-	nonce = server.respondDeletes(0, fooGlob.Name)
-	server.expectACK(nonce)
+	nonce = ms.respondDeletes(0, fooGlob.Name)
+	ms.expectACK(nonce)
 	wildcardH.WaitForDelete(t, fooGlob.Name)
 	globH.WaitForDelete(t, fooGlob.Name)
 
@@ -266,46 +267,46 @@ func testADSClientFlow(t *testing.T, chunkingEnabled bool) {
 	// exists. The client must figure out that barGlob has disappeared while it was disconnected. The
 	// same is true for the wildcard subscription: the client will not receive an explicit notification
 	// that barGlob has disappeared.
-	closeStream()
-	closeStream = server.accept()
-	server.expectSubscriptions(foo.Name, ads.WildcardSubscription, gcURL.String())
+	ms.cancel()
+	ms = conn.accept()
+	ms.expectSubscriptions(foo.Name, ads.WildcardSubscription, gcURL.String())
 
 	nonce = respond[*Timestamp](
-		server,
+		ms,
 		// The only remaining resource is bar
 		[]*ads.Resource[*Timestamp]{bar},
 		// These are explicitly subscribed to but do not exist, so explicit removals are expected
 		[]string{foo.Name, gcURL.String()},
 		0,
 	)
-	server.respondUpdates(0, bar)
-	server.expectACK(nonce)
+	ms.respondUpdates(0, bar)
+	ms.expectACK(nonce)
 	globH.WaitForDelete(t, barGlob.Name)
 	wildcardH.WaitForDelete(t, barGlob.Name)
 
 	// This is an edge case, but bar is known because of the wildcard subscription. Therefore, even while
 	// the client is offline, subscribing to bar should deliver the notification.
-	closeStream()
+	ms.cancel()
 	barH := make(testutils.ChanSubscriptionHandler[*Timestamp], 1)
 	Watch(client, bar.Name, ChanWatcher[*Timestamp](barH))
 	barH.WaitForUpdate(t, bar)
-	closeStream = server.accept()
+	ms = conn.accept()
 	// There should be an explicit subscription sent, but because bar is already known, no further
 	// updates should be received.
-	server.expectSubscriptions(foo.Name, bar.Name, ads.WildcardSubscription, gcURL.String())
-	nonce = server.respondUpdates(0, bar)
-	server.expectACK(nonce)
+	ms.expectSubscriptions(foo.Name, bar.Name, ads.WildcardSubscription, gcURL.String())
+	nonce = ms.respondUpdates(0, bar)
+	ms.expectACK(nonce)
 	checkNoUpdate(t, barH)
 
 	// Delete bar, the final resource
-	nonce = server.respondDeletes(0, bar.Name)
-	server.expectACK(nonce)
+	nonce = ms.respondDeletes(0, bar.Name)
+	ms.expectACK(nonce)
 
 	barH.WaitForDelete(t, bar.Name)
 	wildcardH.WaitForDelete(t, bar.Name)
 
 	// Disconnect again to test what happens when Watch is called while offline for glob and wildcards.
-	closeStream()
+	ms.cancel()
 	allResources := new(map[string]*ads.Resource[*Timestamp])
 	Watch(client, ads.WildcardSubscription, OnceWatcher(allResources))
 	// This should be immediately ready, as data has been received and far as the client knows, there are
@@ -355,89 +356,92 @@ func OnceWatcher[T proto.Message](m *map[string]*ads.Resource[T]) Watcher[T] {
 	}}
 }
 
-type mockServer struct {
-	t         *testing.T
-	requests  chan *ads.DeltaDiscoveryRequest
-	responses chan *ads.DeltaDiscoveryResponse
-	kill      chan chan struct{}
-	group     errgroup.Group
+type mockConn struct {
+	t       *testing.T
+	streams chan *mockStream
+	group   errgroup.Group
 }
 
-func newMockServer(t *testing.T) *mockServer {
-	ms := &mockServer{
-		t:         t,
-		requests:  make(chan *ads.DeltaDiscoveryRequest),
-		responses: make(chan *ads.DeltaDiscoveryResponse),
-		kill:      make(chan chan struct{}),
-	}
-	return ms
-}
-
-func (ms *mockServer) interceptor() grpc.StreamServerInterceptor {
-	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		kill := <-ms.kill
-		go func() {
-			_ = handler(srv, ss)
-		}()
-		<-kill
-		return context.Canceled
-	}
-}
-
-func (ms *mockServer) StreamAggregatedResources(ads.SotWStream) error {
-	return status.Errorf(codes.Unimplemented, "not implemented")
-}
-
-func (ms *mockServer) DeltaAggregatedResources(stream ads.DeltaStream) error {
-	ms.group.Go(func() error {
-		for {
-			select {
-			case res := <-ms.responses:
-				ms.t.Logf("Responding: %+v", res)
-				err := stream.Send(res)
-				if err != nil {
-					return nil
-				}
-			case <-stream.Context().Done():
-				return nil
-			}
-		}
-	})
-	ms.group.Go(func() error {
-		for {
-			req, err := stream.Recv()
-			if err != nil {
-				return nil
-			}
-			ms.t.Logf("Received request: %+v", req)
-			select {
-			case ms.requests <- req:
-			case <-stream.Context().Done():
-				return nil
-			}
-		}
-	})
+func (mc *mockConn) Invoke(context.Context, string, any, any, ...grpc.CallOption) error {
+	mc.t.Fatalf("Not supported")
 	return nil
 }
 
-func (ms *mockServer) accept() context.CancelFunc {
-	ch := make(chan struct{})
-	ms.kill <- ch
-	return sync.OnceFunc(func() {
-		ms.t.Log("Stream killed")
-		close(ch)
-		require.NoError(ms.t, ms.group.Wait())
-	})
+func (mc *mockConn) NewStream(
+	_ context.Context,
+	_ *grpc.StreamDesc,
+	method string,
+	_ ...grpc.CallOption,
+) (grpc.ClientStream, error) {
+	require.Equal(mc.t, discovery.AggregatedDiscoveryService_DeltaAggregatedResources_FullMethodName, method)
+	return <-mc.streams, nil
 }
 
-func (ms *mockServer) respondUpdates(
+func (mc *mockConn) accept() *mockStream {
+	s := &mockStream{
+		conn:      mc,
+		requests:  make(chan *ads.DeltaDiscoveryRequest),
+		responses: make(chan *ads.DeltaDiscoveryResponse),
+	}
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+	mc.streams <- s
+	return s
+}
+
+type mockStream struct {
+	conn      *mockConn
+	ctx       context.Context
+	cancel    context.CancelFunc
+	requests  chan *ads.DeltaDiscoveryRequest
+	responses chan *ads.DeltaDiscoveryResponse
+}
+
+func (ms *mockStream) Header() (metadata.MD, error) {
+	return nil, nil
+}
+
+func (ms *mockStream) Trailer() metadata.MD {
+	return nil
+}
+
+func (ms *mockStream) CloseSend() error {
+	ms.conn.t.Fatalf("Not supported")
+	return nil
+}
+
+func (ms *mockStream) Context() context.Context {
+	return ms.ctx
+}
+
+func (ms *mockStream) SendMsg(msg any) error {
+	require.IsType(ms.conn.t, (*ads.DeltaDiscoveryRequest)(nil), msg)
+	select {
+	case ms.requests <- msg.(*ads.DeltaDiscoveryRequest):
+		return nil
+	case <-ms.ctx.Done():
+		return ms.ctx.Err()
+	}
+}
+
+func (ms *mockStream) RecvMsg(msg any) error {
+	require.IsType(ms.conn.t, (*ads.DeltaDiscoveryResponse)(nil), msg)
+	select {
+	case res := <-ms.responses:
+		proto.Merge(msg.(*ads.DeltaDiscoveryResponse), res)
+		return nil
+	case <-ms.ctx.Done():
+		return ms.ctx.Err()
+	}
+}
+
+func (ms *mockStream) respondUpdates(
 	remainingChunks int,
 	resources ...*ads.Resource[*Timestamp],
 ) string {
 	return respond[*Timestamp](ms, resources, nil, remainingChunks)
 }
 
-func (ms *mockServer) respondDeletes(
+func (ms *mockStream) respondDeletes(
 	remainingChunks int,
 	removedResources ...string,
 ) string {
@@ -445,7 +449,7 @@ func (ms *mockServer) respondDeletes(
 }
 
 func respond[T proto.Message](
-	ms *mockServer,
+	ms *mockStream,
 	resources []*ads.Resource[T],
 	removedResources []string,
 	remainingChunks int,
@@ -453,7 +457,7 @@ func respond[T proto.Message](
 	var marshaled []*ads.RawResource
 	for _, resource := range resources {
 		raw, err := resource.Marshal()
-		require.NoError(ms.t, err)
+		require.NoError(ms.conn.t, err)
 		marshaled = append(marshaled, raw)
 	}
 	nonce := utils.NewNonce(remainingChunks)
@@ -466,24 +470,24 @@ func respond[T proto.Message](
 	return nonce
 }
 
-func (ms *mockServer) expectACK(nonce string) {
+func (ms *mockStream) expectACK(nonce string) {
 	req := <-ms.requests
-	require.Equal(ms.t, utils.GetTypeURL[*Timestamp](), req.TypeUrl)
-	require.Equal(ms.t, nonce, req.ResponseNonce)
+	require.Equal(ms.conn.t, utils.GetTypeURL[*Timestamp](), req.TypeUrl)
+	require.Equal(ms.conn.t, nonce, req.ResponseNonce)
 }
 
-func expectNACK[T proto.Message](ms *mockServer, nonce string, code codes.Code, errorContains string) {
+func expectNACK[T proto.Message](ms *mockStream, nonce string, code codes.Code, errorContains string) {
 	req := <-ms.requests
-	require.Equal(ms.t, utils.GetTypeURL[T](), req.TypeUrl)
-	require.Equal(ms.t, nonce, req.ResponseNonce)
+	require.Equal(ms.conn.t, utils.GetTypeURL[T](), req.TypeUrl)
+	require.Equal(ms.conn.t, nonce, req.ResponseNonce)
 	st := status.FromProto(req.GetErrorDetail())
-	require.Equal(ms.t, code, st.Code())
-	require.ErrorContains(ms.t, st.Err(), errorContains)
+	require.Equal(ms.conn.t, code, st.Code())
+	require.ErrorContains(ms.conn.t, st.Err(), errorContains)
 }
 
-func (ms *mockServer) expectSubscriptions(subscriptions ...string) {
+func (ms *mockStream) expectSubscriptions(subscriptions ...string) {
 	req := <-ms.requests
-	require.Equal(ms.t, utils.GetTypeURL[*Timestamp](), req.TypeUrl)
-	require.Empty(ms.t, req.ResponseNonce)
-	require.ElementsMatch(ms.t, subscriptions, req.ResourceNamesSubscribe)
+	require.Equal(ms.conn.t, utils.GetTypeURL[*Timestamp](), req.TypeUrl)
+	require.Empty(ms.conn.t, req.ResponseNonce)
+	require.ElementsMatch(ms.conn.t, subscriptions, req.ResourceNamesSubscribe)
 }


### PR DESCRIPTION
Instead of relying on interceptors and spinning up an actual gRPC server during the test, this mocks the connection altogether. This guarantees proper ordering during the test and avoids the race condition that is currently blocking HEAD: https://github.com/linkedin/diderot/actions/runs/13975839402/job/39129266449

Tested by running the following, to ensure the race condition does not occur again:
```
go test -run TestADSClient -race -count=10 .
```