### PR TITLE
Adding ClearInitialResourceVersions 

### DIFF
--- a/ads/ads.go
+++ b/ads/ads.go
@@ -202,6 +202,10 @@ type RawSubscriptionHandler interface {
 	// rare and requires immediate attention. When a resource cannot be marshaled, the notification will
 	// be dropped and Notify will not be invoked.
 	ResourceMarshalError(name string, resource proto.Message, err error)
+
+	// ClearInitialResourceVersions is invoked when the initial resource versions can't be supported by the xds servers business logic.
+	// This provides a way to clear the initial resource versions for resource, so that it can be handled correctly by handler while responding to xds client.
+	ClearInitialResourceVersions()
 }
 
 // SubscriptionMetadata contains metadata about the subscription that triggered the Notify call on

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -282,6 +282,12 @@ func (h *handler) ResourceMarshalError(name string, resource proto.Message, err 
 	}
 }
 
+func (h *handler) ClearInitialResourceVersions() {
+	if h.initialResourceVersions != nil {
+		h.initialResourceVersions = nil
+	}
+}
+
 func (h *handler) StartNotificationBatch(initialResourceVersions map[string]string) {
 	h.lock.Lock()
 	defer h.lock.Unlock()

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -305,7 +305,6 @@ func (h *handler) EndNotificationBatch() {
 	}
 
 	h.batchStarted = false
-
 	if len(h.entries) > 0 {
 		h.immediateNotificationReceived.notify()
 		h.notificationReceived.notify()

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -298,7 +298,7 @@ func (h *handler) EndNotificationBatch() {
 	h.lock.Lock()
 	defer h.lock.Unlock()
 
-	for name, _ := range h.initialResourceVersion {
+	for name := range h.initialResourceVersion {
 		if _, found := h.entries[name]; found && h.initialResourceVersion[name].received {
 			h.entries[name] = nil
 		}

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -130,7 +130,7 @@ func TestHandlerBatching(t *testing.T) {
 		expectedEntries[name] = nil
 	}
 
-	h.StartNotificationBatch()
+	h.StartNotificationBatch(nil)
 	notify()
 
 	for i := 0; i < 100; i++ {
@@ -167,7 +167,7 @@ func TestHandlerDoesNothingOnEmptyBatch(t *testing.T) {
 			return nil
 		},
 	)
-	h.StartNotificationBatch()
+	h.StartNotificationBatch(nil)
 	h.EndNotificationBatch()
 }
 
@@ -218,4 +218,121 @@ func TestPseudoDeltaSotWHandler(t *testing.T) {
 	l.Release()
 	require.WithinDuration(t, time.Now(), start.Add(wait), 10*time.Millisecond)
 	require.ElementsMatch(t, []*anypb.Any{testutils.MustMarshal(t, bazR).Resource}, lastRes.Resources)
+}
+
+func TestHandlerBatchingWithIRV(t *testing.T) {
+	var released atomic.Bool
+	ch := make(chan map[string]entry)
+	granular := NewTestHandlerLimiter()
+	handler := newHandler(
+		testutils.Context(t),
+		granular,
+		NoopLimiter{},
+		new(customStatsHandler),
+		false,
+		func(resources map[string]entry) error {
+			// Double check that send isn't invoked before it's expected
+			if !released.Load() {
+				t.Fatalf("send invoked before release!")
+			}
+			ch <- maps.Clone(resources)
+			return nil
+		},
+	)
+
+	notify := func(name string, version string, deleted bool) {
+		newRawResource := newRawResource(name, version)
+		if deleted {
+			newRawResource = nil
+		}
+		handler.Notify(name, newRawResource, ads.SubscriptionMetadata{})
+	}
+
+	expectedEntries := make(map[string]entry)
+
+	// case 1: when initial resource version is not being used.
+	handler.StartNotificationBatch(nil)
+	notify("foo", "0", false)
+	notify("bar", "0", false)
+	expectedEntries["bar"] = entry{
+		Resource: newRawResource("bar", "0"),
+		metadata: ads.SubscriptionMetadata{},
+	}
+	expectedEntries["foo"] = entry{
+		Resource: newRawResource("foo", "0"),
+		metadata: ads.SubscriptionMetadata{},
+	}
+	notify("foo", "0", false)
+	notify("bar", "0", false)
+
+	released.Store(true)
+	handler.EndNotificationBatch()
+	require.Equal(t, expectedEntries, <-ch)
+
+	clear(expectedEntries)
+
+	// case 2: when foo is not updated and bar is updated
+	req := newDeltaReq([]string{"foo", "bar"}, map[string]string{"foo": "0", "bar": "0"})
+	handler.StartNotificationBatch(req.InitialResourceVersions)
+	expectedEntries["bar"] = entry{
+		Resource: newRawResource("bar", "1"),
+		metadata: ads.SubscriptionMetadata{},
+	}
+	notify("foo", "0", false)
+	notify("bar", "1", false)
+
+	released.Store(true)
+	handler.EndNotificationBatch()
+	require.Equal(t, expectedEntries, <-ch)
+
+	clear(expectedEntries)
+
+	// case 3: when foo is deleted and bar is not updated
+	req = newDeltaReq([]string{"foo", "bar"}, map[string]string{"foo": "0", "bar": "0"})
+	handler.StartNotificationBatch(req.InitialResourceVersions)
+	notify("foo", "0", true)
+	notify("bar", "0", false)
+	expectedEntries["foo"] = entry{
+		Resource: nil,
+		metadata: ads.SubscriptionMetadata{},
+	}
+	released.Store(true)
+	handler.EndNotificationBatch()
+	require.Equal(t, expectedEntries, <-ch)
+
+	clear(expectedEntries)
+
+	// case 3: when foo is deleted and bar is updated and foo is re-created again
+	req = newDeltaReq([]string{"foo", "bar"}, map[string]string{"foo": "0", "bar": "0"})
+	handler.StartNotificationBatch(req.InitialResourceVersions)
+	notify("foo", "0", true)
+	notify("bar", "1", false)
+	notify("foo", "1", false)
+	expectedEntries["bar"] = entry{
+		Resource: newRawResource("bar", "1"),
+		metadata: ads.SubscriptionMetadata{},
+	}
+	expectedEntries["foo"] = entry{
+		Resource: newRawResource("foo", "1"),
+		metadata: ads.SubscriptionMetadata{},
+	}
+	released.Store(true)
+	handler.EndNotificationBatch()
+	require.Equal(t, expectedEntries, <-ch)
+}
+
+func newDeltaReq(subscribe []string, versions map[string]string) *ads.DeltaDiscoveryRequest {
+	return &ads.DeltaDiscoveryRequest{
+		ResourceNamesSubscribe:  subscribe,
+		InitialResourceVersions: versions,
+	}
+}
+
+func newRawResource(name string, version string) *ads.RawResource {
+	return &ads.RawResource{
+		Name:     name,
+		Version:  version,
+		Resource: &anypb.Any{},
+	}
+
 }

--- a/internal/server/subscription_manager.go
+++ b/internal/server/subscription_manager.go
@@ -113,7 +113,7 @@ func NewSotWSubscriptionManager(
 //
 // [the spec]: https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol.html#how-the-client-specifies-what-resources-to-return
 func (m *deltaSubscriptionManager) ProcessSubscriptions(req *ads.DeltaDiscoveryRequest) {
-	m.handler.StartNotificationBatch()
+	m.handler.StartNotificationBatch(req.InitialResourceVersions)
 	defer m.handler.EndNotificationBatch()
 
 	m.lock.Lock()
@@ -144,7 +144,7 @@ func (m *deltaSubscriptionManager) ProcessSubscriptions(req *ads.DeltaDiscoveryR
 //
 // [the spec]: https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol.html#how-the-client-specifies-what-resources-to-return
 func (m *sotWSubscriptionManager) ProcessSubscriptions(req *ads.SotWDiscoveryRequest) {
-	m.handler.StartNotificationBatch()
+	m.handler.StartNotificationBatch(nil)
 	defer m.handler.EndNotificationBatch()
 
 	m.lock.Lock()

--- a/server_test.go
+++ b/server_test.go
@@ -496,7 +496,7 @@ type simpleBatchHandler struct {
 	ch     atomic.Pointer[chan struct{}]
 }
 
-func (h *simpleBatchHandler) StartNotificationBatch() {
+func (h *simpleBatchHandler) StartNotificationBatch(map[string]string) {
 	ch := make(chan struct{}, 1)
 	require.True(h.t, h.ch.CompareAndSwap(nil, &ch))
 }
@@ -795,13 +795,13 @@ func TestImplicitWildcardSubscription(t *testing.T) {
 // batchFuncHandler the equivalent of funcHandler but for the BatchSubscriptionHandler interface.
 type batchFuncHandler struct {
 	t      *testing.T
-	start  func()
+	start  func(irv map[string]string)
 	notify func(name string, r *ads.RawResource, metadata ads.SubscriptionMetadata)
 	end    func()
 }
 
-func (b *batchFuncHandler) StartNotificationBatch() {
-	b.start()
+func (b *batchFuncHandler) StartNotificationBatch(irv map[string]string) {
+	b.start(irv)
 }
 
 func (b *batchFuncHandler) Notify(name string, r *ads.RawResource, metadata ads.SubscriptionMetadata) {
@@ -818,7 +818,7 @@ func (b *batchFuncHandler) EndNotificationBatch() {
 
 func NewBatchSubscriptionHandler(
 	t *testing.T,
-	start func(),
+	start func(versions map[string]string),
 	notify func(name string, r *ads.RawResource, metadata ads.SubscriptionMetadata),
 	end func(),
 ) internal.BatchSubscriptionHandler {
@@ -833,7 +833,7 @@ func NewBatchSubscriptionHandler(
 func NewNoopBatchSubscriptionHandler(t *testing.T) internal.BatchSubscriptionHandler {
 	return NewBatchSubscriptionHandler(
 		t,
-		func() {}, func(string, *ads.RawResource, ads.SubscriptionMetadata) {}, func() {},
+		func(map[string]string) {}, func(string, *ads.RawResource, ads.SubscriptionMetadata) {}, func() {},
 	)
 }
 


### PR DESCRIPTION
Adding ClearInitialResourceVersions so observer have a way to reset the IRV if it's not supported for any resource type. 