### PR TITLE
Wire in context for SendBufferSizeEstimator

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -15,7 +15,7 @@ import (
 
 // SendBufferSizeEstimator is a copy of the interface in the root package, to avoid import cycles.
 type SendBufferSizeEstimator interface {
-	EstimateSubscriptionSize(typeURL string, resourceNamesSubscribe []string) int
+	EstimateSubscriptionSize(streamCtx context.Context, typeURL string, resourceNamesSubscribe []string) int
 }
 
 // BatchSubscriptionHandler is an extension of the SubscriptionHandler interface in the root package

--- a/internal/server/subscription_manager.go
+++ b/internal/server/subscription_manager.go
@@ -228,7 +228,7 @@ func (c *subscriptionManagerCore) cleanSubscriptionsAndEstimateSize(
 	slices.Sort(cleaned)
 	cleaned = slices.Compact(cleaned)
 	if len(initialResourceVersions) == 0 && c.sizeEstimator != nil {
-		size = c.sizeEstimator.EstimateSubscriptionSize(c.typeURL, cleaned)
+		size = c.sizeEstimator.EstimateSubscriptionSize(c.ctx, c.typeURL, cleaned)
 	}
 	return cleaned, size
 }

--- a/server.go
+++ b/server.go
@@ -158,7 +158,7 @@ func WithControlPlane(controlPlane *corev3.ControlPlane) ADSServerOption {
 type SendBufferSizeEstimator interface {
 	// EstimateSubscriptionSize returns the expected number of resources that will be sent back as a
 	// result of the given resource names.
-	EstimateSubscriptionSize(typeURL string, resourceNamesSubscribe []string) int
+	EstimateSubscriptionSize(streamCtx context.Context, typeURL string, resourceNamesSubscribe []string) int
 }
 
 // WithSendBufferSizeEstimator provides a [SendBufferSizeEstimator] that will be invoked when the


### PR DESCRIPTION
The context is meant to be used by implementations of `ResourceLocator` and `SendBufferSizeEstimator` to determine the client type. Without the context, it is impossible to do this and therefore to locate the right cache to estimate the send buffer with.