### PR TITLE
Change API for checking resource queue time

### DIFF
--- a/ads/ads.go
+++ b/ads/ads.go
@@ -207,13 +207,13 @@ type RawSubscriptionHandler interface {
 // SubscriptionMetadata contains metadata about the subscription that triggered the Notify call on
 // the [RawSubscriptionHandler] or [SubscriptionHandler].
 type SubscriptionMetadata struct {
-	// The time at which the resource was subscribed to
+	// The time at which the resource was subscribed to.
 	SubscribedAt time.Time
-	// The time at which the resource was modified (can be UnknownModifiedTime if the modification time is unknown)
+	// The time at which the resource was modified (can be the 0-value if the modification time is unknown).
 	ModifiedAt time.Time
 	// The time at which the update to the resource was received by the cache (i.e. when [Cache.Set] was
 	// called, not strictly when the server actually received the update). If this is metadata is for a
-	// subscription to a resource that does not yet exist, will be UnknownModifiedTime.
+	// subscription to a resource that does not yet exist, will be the 0-value.
 	CachedAt time.Time
 	// The current priority index of the value. Will be 0 unless the backing cache was created with
 	// [NewPrioritizedCache], [NewPrioritizedAggregateCache] or

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -34,7 +34,7 @@ type BatchSubscriptionHandler interface {
 
 // sendBuffer is an alias for the map type used by the handler to accumulate pending resource updates
 // before sending them to the client.
-type sendBuffer map[string]serverstats.QueuedResource
+type sendBuffer map[string]serverstats.SentResource
 
 func newHandler(
 	ctx context.Context,
@@ -172,10 +172,20 @@ func (h *handler) loop() {
 
 		entries := h.swapEntries()
 
+		var start time.Time
 		if h.statsHandler != nil {
-			h.statsHandler.HandleServerEvent(h.ctx, &serverstats.ResourcesQueued{Resources: entries})
+			start = time.Now()
 		}
+
 		err := h.send(entries)
+
+		if h.statsHandler != nil {
+			h.statsHandler.HandleServerEvent(h.ctx, &serverstats.ResponseSent{
+				TypeURL:   h.typeURL,
+				Resources: entries,
+				Duration:  time.Since(start),
+			})
+		}
 
 		// Return the used map to the pool after clearing it.
 		clear(entries)
@@ -259,9 +269,10 @@ func (h *handler) Notify(name string, r *ads.RawResource, metadata ads.Subscript
 		return
 	}
 
-	h.entries[name] = serverstats.QueuedResource{
+	h.entries[name] = serverstats.SentResource{
 		Resource: r,
 		Metadata: metadata,
+		QueuedAt: time.Now(),
 	}
 
 	if r != nil && metadata.GlobCollectionURL != "" {
@@ -342,7 +353,7 @@ func (h *handler) handleDeletionsFromIRV() {
 		if _, ok := h.entries[name]; !ok && !irv.received {
 			slog.Debug("Resource no longer exists on the server but is still present on the client. "+
 				"Explicitly marking the resource for deletion.", "resourceName", name)
-			h.entries[name] = serverstats.QueuedResource{}
+			h.entries[name] = serverstats.SentResource{}
 		}
 	}
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -34,10 +34,11 @@ type BatchSubscriptionHandler interface {
 
 // sendBuffer is an alias for the map type used by the handler to accumulate pending resource updates
 // before sending them to the client.
-type sendBuffer map[string]*ads.RawResource
+type sendBuffer map[string]serverstats.QueuedResource
 
 func newHandler(
 	ctx context.Context,
+	typeURL string,
 	granularLimiter handlerLimiter,
 	globalLimiter handlerLimiter,
 	statsHandler serverstats.Handler,
@@ -45,6 +46,7 @@ func newHandler(
 	send func(entries sendBuffer) error,
 ) *handler {
 	h := &handler{
+		typeURL:                       typeURL,
 		granularLimiter:               granularLimiter,
 		globalLimiter:                 globalLimiter,
 		statsHandler:                  statsHandler,
@@ -95,6 +97,7 @@ var sendBufferPool = sync.Pool{New: func() any { return make(sendBuffer) }}
 // handler implements the BatchSubscriptionHandler interface using a backing map to aggregate updates
 // as they come in, and flushing them out, according to when the limiter permits it.
 type handler struct {
+	typeURL         string
 	granularLimiter handlerLimiter
 	globalLimiter   handlerLimiter
 	statsHandler    serverstats.Handler
@@ -169,6 +172,9 @@ func (h *handler) loop() {
 
 		entries := h.swapEntries()
 
+		if h.statsHandler != nil {
+			h.statsHandler.HandleServerEvent(h.ctx, &serverstats.ResourcesQueued{Resources: entries})
+		}
 		err := h.send(entries)
 
 		// Return the used map to the pool after clearing it.
@@ -234,12 +240,10 @@ func (h *handler) Notify(name string, r *ads.RawResource, metadata ads.Subscript
 	h.lock.Lock()
 	defer h.lock.Unlock()
 
-	if h.statsHandler != nil {
-		h.statsHandler.HandleServerEvent(h.ctx, &serverstats.ResourceQueued{
-			ResourceName:   name,
-			Resource:       r,
-			Metadata:       metadata,
-			ResourceExists: !metadata.CachedAt.IsZero(),
+	if metadata.CachedAt.IsZero() && h.statsHandler != nil {
+		h.statsHandler.HandleServerEvent(h.ctx, &serverstats.UnknownResourceRequested{
+			TypeURL:      h.typeURL,
+			ResourceName: name,
 		})
 	}
 
@@ -255,7 +259,10 @@ func (h *handler) Notify(name string, r *ads.RawResource, metadata ads.Subscript
 		return
 	}
 
-	h.entries[name] = r
+	h.entries[name] = serverstats.QueuedResource{
+		Resource: r,
+		Metadata: metadata,
+	}
 
 	if r != nil && metadata.GlobCollectionURL != "" {
 		// When a glob collection is empty, it is signaled to the client with a corresponding deletion of
@@ -335,7 +342,7 @@ func (h *handler) handleDeletionsFromIRV() {
 		if _, ok := h.entries[name]; !ok && !irv.received {
 			slog.Debug("Resource no longer exists on the server but is still present on the client. "+
 				"Explicitly marking the resource for deletion.", "resourceName", name)
-			h.entries[name] = nil
+			h.entries[name] = serverstats.QueuedResource{}
 		}
 	}
 }
@@ -386,25 +393,25 @@ func newSotWHandler(
 	granularLimiter handlerLimiter,
 	globalLimiter handlerLimiter,
 	statsHandler serverstats.Handler,
-	typeUrl string,
+	typeURL string,
 	send func(res *ads.SotWDiscoveryResponse) error,
 ) *handler {
-	isPseudoDeltaSotW := utils.IsPseudoDeltaSotW(typeUrl)
+	isPseudoDeltaSotW := utils.IsPseudoDeltaSotW(typeURL)
 	var looper func(resources sendBuffer) error
 	if isPseudoDeltaSotW {
 		looper = func(entries sendBuffer) error {
 			versions := map[string]string{}
 
 			for name, e := range entries {
-				versions[name] = e.Version
+				versions[name] = e.Resource.Version
 			}
 
 			res := &ads.SotWDiscoveryResponse{
-				TypeUrl: typeUrl,
+				TypeUrl: typeURL,
 				Nonce:   utils.NewNonce(0),
 			}
 			for _, e := range entries {
-				res.Resources = append(res.Resources, e.Resource)
+				res.Resources = append(res.Resources, e.Resource.Resource)
 			}
 			res.VersionInfo = utils.MapToProto(versions)
 			return send(res)
@@ -415,9 +422,9 @@ func newSotWHandler(
 
 		looper = func(resources sendBuffer) error {
 			for name, r := range resources {
-				if r != nil {
+				if r.Resource != nil {
 					allResources[name] = r
-					versions[name] = r.Version
+					versions[name] = r.Resource.Version
 				} else {
 					delete(allResources, name)
 					delete(versions, name)
@@ -425,11 +432,11 @@ func newSotWHandler(
 			}
 
 			res := &ads.SotWDiscoveryResponse{
-				TypeUrl: typeUrl,
+				TypeUrl: typeURL,
 				Nonce:   utils.NewNonce(0),
 			}
 			for _, r := range allResources {
-				res.Resources = append(res.Resources, r.Resource)
+				res.Resources = append(res.Resources, r.Resource.Resource)
 			}
 			res.VersionInfo = utils.MapToProto(versions)
 			return send(res)
@@ -438,6 +445,7 @@ func newSotWHandler(
 
 	return newHandler(
 		ctx,
+		typeURL,
 		granularLimiter,
 		globalLimiter,
 		statsHandler,

--- a/internal/server/handlers_bench_test.go
+++ b/internal/server/handlers_bench_test.go
@@ -30,7 +30,7 @@ func benchmarkHandlers(tb testing.TB, count, subscriptions int) {
 		false,
 		func(resources sendBuffer) error {
 			for _, r := range resources {
-				if r.Version == finalVersion {
+				if r.Resource.Version == finalVersion {
 					finished.Done()
 				}
 			}

--- a/internal/server/handlers_bench_test.go
+++ b/internal/server/handlers_bench_test.go
@@ -24,6 +24,7 @@ func benchmarkHandlers(tb testing.TB, count, subscriptions int) {
 	const finalVersion = "done"
 	h := newHandler(
 		ctx,
+		AnyTypeURL,
 		NoopLimiter{},
 		NoopLimiter{},
 		new(customStatsHandler),

--- a/internal/server/handlers_delta_test.go
+++ b/internal/server/handlers_delta_test.go
@@ -122,7 +122,7 @@ func TestDeltaHandlerChunking(t *testing.T) {
 		minChunkSize: initialChunkSize(typeURL),
 	}
 
-	getSentResponses := func(resources map[string]*ads.RawResource, expectedChunks int) []*ads.DeltaDiscoveryResponse {
+	getSentResponses := func(resources sendBuffer, expectedChunks int) []*ads.DeltaDiscoveryResponse {
 		responses := ds.chunk(resources)
 		require.Len(t, responses, expectedChunks)
 		expectedRemainingChunks := 0
@@ -135,9 +135,9 @@ func TestDeltaHandlerChunking(t *testing.T) {
 		return responses
 	}
 
-	sentResponses := getSentResponses(map[string]*ads.RawResource{
-		foo.Name: foo,
-		bar.Name: bar,
+	sentResponses := getSentResponses(sendBuffer{
+		foo.Name: serverstats.QueuedResource{Resource: foo},
+		bar.Name: serverstats.QueuedResource{Resource: bar},
 	}, 2)
 	require.Equal(t, len(sentResponses[0].Resources), 1)
 	require.Equal(t, len(sentResponses[1].Resources), 1)
@@ -155,9 +155,9 @@ func TestDeltaHandlerChunking(t *testing.T) {
 	// Delete resources whose names are the same size as the resources to trip the chunker with the same conditions
 	name1 := strings.Repeat("1", resourceSize)
 	name2 := strings.Repeat("2", resourceSize)
-	sentResponses = getSentResponses(map[string]*ads.RawResource{
-		name1: nil,
-		name2: nil,
+	sentResponses = getSentResponses(sendBuffer{
+		name1: serverstats.QueuedResource{Resource: nil},
+		name2: serverstats.QueuedResource{Resource: nil},
 	}, 2)
 	require.Equal(t, len(sentResponses[0].RemovedResources), 1)
 	require.Equal(t, len(sentResponses[1].RemovedResources), 1)
@@ -169,11 +169,11 @@ func TestDeltaHandlerChunking(t *testing.T) {
 	small1, small2, small3 := "a", "b", "c"
 	wayTooBig := strings.Repeat("3", 10*resourceSize)
 
-	sentResponses = getSentResponses(map[string]*ads.RawResource{
-		small1:    nil,
-		small2:    nil,
-		small3:    nil,
-		wayTooBig: nil,
+	sentResponses = getSentResponses(sendBuffer{
+		small1:    serverstats.QueuedResource{Resource: nil},
+		small2:    serverstats.QueuedResource{Resource: nil},
+		small3:    serverstats.QueuedResource{Resource: nil},
+		wayTooBig: serverstats.QueuedResource{Resource: nil},
 	}, 1)
 	require.Equal(t, len(sentResponses[0].RemovedResources), 3)
 	require.ElementsMatch(t, []string{small1, small2, small3}, sentResponses[0].RemovedResources)

--- a/internal/server/handlers_delta_test.go
+++ b/internal/server/handlers_delta_test.go
@@ -136,8 +136,8 @@ func TestDeltaHandlerChunking(t *testing.T) {
 	}
 
 	sentResponses := getSentResponses(sendBuffer{
-		foo.Name: serverstats.QueuedResource{Resource: foo},
-		bar.Name: serverstats.QueuedResource{Resource: bar},
+		foo.Name: serverstats.SentResource{Resource: foo},
+		bar.Name: serverstats.SentResource{Resource: bar},
 	}, 2)
 	require.Equal(t, len(sentResponses[0].Resources), 1)
 	require.Equal(t, len(sentResponses[1].Resources), 1)
@@ -156,8 +156,8 @@ func TestDeltaHandlerChunking(t *testing.T) {
 	name1 := strings.Repeat("1", resourceSize)
 	name2 := strings.Repeat("2", resourceSize)
 	sentResponses = getSentResponses(sendBuffer{
-		name1: serverstats.QueuedResource{Resource: nil},
-		name2: serverstats.QueuedResource{Resource: nil},
+		name1: serverstats.SentResource{Resource: nil},
+		name2: serverstats.SentResource{Resource: nil},
 	}, 2)
 	require.Equal(t, len(sentResponses[0].RemovedResources), 1)
 	require.Equal(t, len(sentResponses[1].RemovedResources), 1)
@@ -170,10 +170,10 @@ func TestDeltaHandlerChunking(t *testing.T) {
 	wayTooBig := strings.Repeat("3", 10*resourceSize)
 
 	sentResponses = getSentResponses(sendBuffer{
-		small1:    serverstats.QueuedResource{Resource: nil},
-		small2:    serverstats.QueuedResource{Resource: nil},
-		small3:    serverstats.QueuedResource{Resource: nil},
-		wayTooBig: serverstats.QueuedResource{Resource: nil},
+		small1:    serverstats.SentResource{Resource: nil},
+		small2:    serverstats.SentResource{Resource: nil},
+		small3:    serverstats.SentResource{Resource: nil},
+		wayTooBig: serverstats.SentResource{Resource: nil},
 	}, 1)
 	require.Equal(t, len(sentResponses[0].RemovedResources), 3)
 	require.ElementsMatch(t, []string{small1, small2, small3}, sentResponses[0].RemovedResources)

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -8,16 +8,26 @@ import (
 	"testing"
 	"time"
 
+	gocmp "github.com/google/go-cmp/cmp"
+	gocmpopts "github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/linkedin/diderot/ads"
 	"github.com/linkedin/diderot/internal/utils"
 	serverstats "github.com/linkedin/diderot/stats/server"
 	"github.com/linkedin/diderot/testutils"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 const AnyTypeURL = "type.googleapis.com/google.protobuf.Any"
+
+func checkSendBuffer(t *testing.T, expected, actual sendBuffer) {
+	opts := []gocmp.Option{gocmpopts.IgnoreFields(serverstats.SentResource{}, "QueuedAt"), protocmp.Transform()}
+	if !gocmp.Equal(expected, actual, opts...) {
+		require.Equal(t, expected, actual)
+	}
+}
 
 // TestHandlerDebounce checks the following:
 //  1. That the handler does not invoke send as long as the debouncer has not allowed it to.
@@ -89,29 +99,23 @@ func TestHandlerDebounce(t *testing.T) {
 
 	released.Store(true)
 	l.Release()
-	require.Equal(t,
-		sendBuffer{
-			foo: serverstats.QueuedResource{
-				Resource: nil,
-				Metadata: fooDeleteMetadata,
-			},
+	checkSendBuffer(t, sendBuffer{
+		foo: serverstats.SentResource{
+			Resource: nil,
+			Metadata: fooDeleteMetadata,
 		},
-		actualResources)
+	}, actualResources)
 	delete(actualResources, foo)
 
 	enterSendWg.Add(1)
 	released.Store(true)
 	l.Release()
-	require.Equal(
-		t,
-		sendBuffer{
-			bar: serverstats.QueuedResource{
-				Resource: barR,
-				Metadata: barCreateMetadata,
-			},
+	checkSendBuffer(t, sendBuffer{
+		bar: serverstats.SentResource{
+			Resource: barR,
+			Metadata: barCreateMetadata,
 		},
-		actualResources,
-	)
+	}, actualResources)
 }
 
 func TestHandlerBatching(t *testing.T) {
@@ -138,7 +142,7 @@ func TestHandlerBatching(t *testing.T) {
 	notify := func() {
 		name := strconv.Itoa(len(expectedEntries))
 		h.Notify(name, nil, ads.SubscriptionMetadata{})
-		expectedEntries[name] = serverstats.QueuedResource{Resource: nil}
+		expectedEntries[name] = serverstats.SentResource{Resource: nil}
 	}
 
 	h.StartNotificationBatch(nil, 0)
@@ -150,7 +154,7 @@ func TestHandlerBatching(t *testing.T) {
 	released.Store(true)
 	h.EndNotificationBatch()
 
-	require.Equal(t, expectedEntries, <-ch)
+	checkSendBuffer(t, expectedEntries, <-ch)
 
 	released.Store(false)
 
@@ -162,7 +166,7 @@ func TestHandlerBatching(t *testing.T) {
 	// Check that EndNotificationBatch skips the granular limiter
 	h.EndNotificationBatch()
 
-	require.Equal(t, expectedEntries, <-ch)
+	checkSendBuffer(t, expectedEntries, <-ch)
 }
 
 func TestHandlerDoesNothingOnEmptyBatch(t *testing.T) {
@@ -264,7 +268,9 @@ func TestHandlerBatchingWithIRV(t *testing.T) {
 		notify(bar, barResource)
 		released.Store(true)
 		handler.EndNotificationBatch()
-		require.Equal(t, sendBuffer{barResource.Name: serverstats.QueuedResource{Resource: barResource}}, <-ch)
+		checkSendBuffer(t, sendBuffer{
+			barResource.Name: serverstats.SentResource{Resource: barResource},
+		}, <-ch)
 	})
 
 	t.Run("partial update, foo deleted and bar updated", func(t *testing.T) {
@@ -274,9 +280,9 @@ func TestHandlerBatchingWithIRV(t *testing.T) {
 		notify(bar, barResource)
 		released.Store(true)
 		handler.EndNotificationBatch()
-		require.Equal(t, sendBuffer{
-			barResource.Name: serverstats.QueuedResource{Resource: barResource},
-			foo:              serverstats.QueuedResource{Resource: nil},
+		checkSendBuffer(t, sendBuffer{
+			barResource.Name: serverstats.SentResource{Resource: barResource},
+			foo:              serverstats.SentResource{Resource: nil},
 		}, <-ch)
 	})
 
@@ -287,9 +293,9 @@ func TestHandlerBatchingWithIRV(t *testing.T) {
 		notify(bar, barResource)
 		released.Store(true)
 		handler.EndNotificationBatch()
-		require.Equal(t, sendBuffer{
-			barResource.Name: serverstats.QueuedResource{Resource: barResource},
-			foo:              serverstats.QueuedResource{Resource: nil},
+		checkSendBuffer(t, sendBuffer{
+			barResource.Name: serverstats.SentResource{Resource: barResource},
+			foo:              serverstats.SentResource{Resource: nil},
 		}, <-ch)
 	})
 }

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -17,6 +17,8 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
+const AnyTypeURL = "type.googleapis.com/google.protobuf.Any"
+
 // TestHandlerDebounce checks the following:
 //  1. That the handler does not invoke send as long as the debouncer has not allowed it to.
 //  2. That updates that come in while send is being invoked do not get missed.
@@ -32,6 +34,7 @@ func TestHandlerDebounce(t *testing.T) {
 
 	h := newHandler(
 		testutils.Context(t),
+		AnyTypeURL,
 		NoopLimiter{},
 		l,
 		new(customStatsHandler),
@@ -89,9 +92,8 @@ func TestHandlerDebounce(t *testing.T) {
 	require.Equal(t,
 		sendBuffer{
 			foo: serverstats.QueuedResource{
-				Resource:       nil,
-				Metadata:       fooDeleteMetadata,
-				ResourceExists: true,
+				Resource: nil,
+				Metadata: fooDeleteMetadata,
 			},
 		},
 		actualResources)
@@ -104,9 +106,8 @@ func TestHandlerDebounce(t *testing.T) {
 		t,
 		sendBuffer{
 			bar: serverstats.QueuedResource{
-				Resource:       barR,
-				Metadata:       barCreateMetadata,
-				ResourceExists: true,
+				Resource: barR,
+				Metadata: barCreateMetadata,
 			},
 		},
 		actualResources,
@@ -119,6 +120,7 @@ func TestHandlerBatching(t *testing.T) {
 	granular := NewTestHandlerLimiter()
 	h := newHandler(
 		testutils.Context(t),
+		AnyTypeURL,
 		granular,
 		NoopLimiter{},
 		new(customStatsHandler),
@@ -166,6 +168,7 @@ func TestHandlerBatching(t *testing.T) {
 func TestHandlerDoesNothingOnEmptyBatch(t *testing.T) {
 	h := newHandler(
 		testutils.Context(t),
+		AnyTypeURL,
 		// Make both limiters nil, if the handler interacts with them at all the test should fail
 		nil,
 		nil,
@@ -238,6 +241,7 @@ func TestHandlerBatchingWithIRV(t *testing.T) {
 	ch := make(chan sendBuffer)
 	handler := newHandler(
 		testutils.Context(t),
+		AnyTypeURL,
 		NoopLimiter{},
 		NoopLimiter{},
 		new(customStatsHandler),

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/linkedin/diderot/ads"
 	"github.com/linkedin/diderot/internal/utils"
+	serverstats "github.com/linkedin/diderot/stats/server"
 	"github.com/linkedin/diderot/testutils"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -87,7 +88,11 @@ func TestHandlerDebounce(t *testing.T) {
 	l.Release()
 	require.Equal(t,
 		sendBuffer{
-			foo: nil,
+			foo: serverstats.QueuedResource{
+				Resource:       nil,
+				Metadata:       fooDeleteMetadata,
+				ResourceExists: true,
+			},
 		},
 		actualResources)
 	delete(actualResources, foo)
@@ -98,7 +103,11 @@ func TestHandlerDebounce(t *testing.T) {
 	require.Equal(
 		t,
 		sendBuffer{
-			bar: barR,
+			bar: serverstats.QueuedResource{
+				Resource:       barR,
+				Metadata:       barCreateMetadata,
+				ResourceExists: true,
+			},
 		},
 		actualResources,
 	)
@@ -127,7 +136,7 @@ func TestHandlerBatching(t *testing.T) {
 	notify := func() {
 		name := strconv.Itoa(len(expectedEntries))
 		h.Notify(name, nil, ads.SubscriptionMetadata{})
-		expectedEntries[name] = nil
+		expectedEntries[name] = serverstats.QueuedResource{Resource: nil}
 	}
 
 	h.StartNotificationBatch(nil, 0)
@@ -251,7 +260,7 @@ func TestHandlerBatchingWithIRV(t *testing.T) {
 		notify(bar, barResource)
 		released.Store(true)
 		handler.EndNotificationBatch()
-		require.Equal(t, sendBuffer{barResource.Name: barResource}, <-ch)
+		require.Equal(t, sendBuffer{barResource.Name: serverstats.QueuedResource{Resource: barResource}}, <-ch)
 	})
 
 	t.Run("partial update, foo deleted and bar updated", func(t *testing.T) {
@@ -262,8 +271,8 @@ func TestHandlerBatchingWithIRV(t *testing.T) {
 		released.Store(true)
 		handler.EndNotificationBatch()
 		require.Equal(t, sendBuffer{
-			barResource.Name: barResource,
-			foo:              nil,
+			barResource.Name: serverstats.QueuedResource{Resource: barResource},
+			foo:              serverstats.QueuedResource{Resource: nil},
 		}, <-ch)
 	})
 
@@ -275,8 +284,8 @@ func TestHandlerBatchingWithIRV(t *testing.T) {
 		released.Store(true)
 		handler.EndNotificationBatch()
 		require.Equal(t, sendBuffer{
-			barResource.Name: barResource,
-			foo:              nil,
+			barResource.Name: serverstats.QueuedResource{Resource: barResource},
+			foo:              serverstats.QueuedResource{Resource: nil},
 		}, <-ch)
 	})
 }

--- a/server.go
+++ b/server.go
@@ -328,16 +328,6 @@ type streamHandler[REQ adsDiscoveryRequest, RES proto.Message] struct {
 // send invokes Send on the stream with the given response, returning an error if Send returns an error. Crucially,
 // Send can only be invoked by one goroutine at a time, so this function protects the invocation of Send with sendLock.
 func (h *streamHandler[REQ, RES]) send(res RES) (err error) {
-	if h.server.statsHandler != nil {
-		start := time.Now()
-		defer func() {
-			h.server.statsHandler.HandleServerEvent(h.streamCtx, &serverstats.ResponseSent{
-				Res:      res,
-				Duration: time.Since(start),
-			})
-		}()
-	}
-
 	h.sendLock.Lock()
 	defer h.sendLock.Unlock()
 	h.setControlPlane(res, h.server.controlPlane)

--- a/server_test.go
+++ b/server_test.go
@@ -48,10 +48,8 @@ func (m *serverStatsHandler) HandleServerEvent(ctx context.Context, event server
 		if e.IsACK {
 			m.ACKsReceived.Add(1)
 		}
-	case *serverstats.ResourceQueued:
-		if !e.ResourceExists {
-			m.UnknownResources.Add(1)
-		}
+	case *serverstats.UnknownResourceRequested:
+		m.UnknownResources.Add(1)
 	}
 }
 

--- a/stats/server/server_stats.go
+++ b/stats/server/server_stats.go
@@ -35,10 +35,26 @@ type RequestReceived struct {
 
 func (s *RequestReceived) isServerEvent() {}
 
+// SentResource contains all the metadata about a resource sent by the server. Will be the 0-value
+// for any resource that was provided via the initial_resource_versions field which was not
+// explicitly subscribed to and did not exist.
+type SentResource struct {
+	// The resource itself, nil if the resource is being deleted.
+	Resource *ads.RawResource
+	// The metadata for the resource and subscription.
+	Metadata ads.SubscriptionMetadata
+	// The time at which the resource was queued to be sent. This means that it does not include any time
+	// spent in the granular or global rate limiters, or sending the response, which can take an arbitrarily
+	// long time due to flow control.
+	QueuedAt time.Time
+}
+
 // ResponseSent contains the stats of a response sent by the server.
 type ResponseSent struct {
-	// The response sent, either [ads.SotWDiscoveryResponse] or [ads.DeltaDiscoveryResponse].
-	Res proto.Message
+	// The type URL of the resources in the response.
+	TypeURL string
+	// The resources that were sent.
+	Resources map[string]SentResource
 	// How long the Send operation took. This includes any time added by flow-control.
 	Duration time.Duration
 }
@@ -80,24 +96,6 @@ type ResourceOverMaxSize struct {
 
 func (s *ResourceOverMaxSize) isServerEvent() {}
 
-// QueuedResource contains all the metadata about a resource about to be sent by the server. Will be
-// the 0-value for any resource that was provided via the initial_resource_versions field which was
-// not explicitly subscribed to and did not exist.
-type QueuedResource struct {
-	// The resource itself, nil if the resource is being deleted.
-	Resource *ads.RawResource
-	// The metadata for the resource and subscription.
-	Metadata ads.SubscriptionMetadata
-}
-
-// ResourcesQueued contains the stats for resources about to be sent.
-type ResourcesQueued struct {
-	// Iterates over all the resources about to be sent.
-	Resources map[string]QueuedResource
-}
-
-func (s *ResourcesQueued) isServerEvent() {}
-
 // IRVMatchedResource represents stats for resources that are not sent by the server
 // because their version matches the `initial_resource_versions` provided in the client request.
 type IRVMatchedResource struct {
@@ -110,7 +108,9 @@ type IRVMatchedResource struct {
 func (s *IRVMatchedResource) isServerEvent() {}
 
 // UnknownResourceRequested indicates whether a resource that was subscribed never existed. This
-// should be rare, and can be indicative of a client-side bug.
+// should be rare, and can be indicative of a bug (either the client is requesting an unknown
+// resource because it is incorrectly configured, or the server is missing some resource that it is
+// expected to have).
 type UnknownResourceRequested struct {
 	// The resource's type.
 	TypeURL string

--- a/stats/server/server_stats.go
+++ b/stats/server/server_stats.go
@@ -80,21 +80,23 @@ type ResourceOverMaxSize struct {
 
 func (s *ResourceOverMaxSize) isServerEvent() {}
 
-// ResourceQueued contains the stats for a resource entering the send queue.
-type ResourceQueued struct {
-	// The name of the resource
-	ResourceName string
+// QueuedResource contains all the metadata about a resource about to be sent by the server. Will be
+// the 0-value for any resource that was provided via the initial_resource_versions field which was
+// not explicitly subscribed to and did not exist.
+type QueuedResource struct {
 	// The resource itself, nil if the resource is being deleted.
 	Resource *ads.RawResource
 	// The metadata for the resource and subscription.
 	Metadata ads.SubscriptionMetadata
-	// Indicates whether the resource existed at all and is being deleted, or whether the client
-	// subscribed to a resource that never existed. This should be rare, and can be indicative of a
-	// client-side bug.
-	ResourceExists bool
 }
 
-func (s *ResourceQueued) isServerEvent() {}
+// ResourcesQueued contains the stats for resources about to be sent.
+type ResourcesQueued struct {
+	// Iterates over all the resources about to be sent.
+	Resources map[string]QueuedResource
+}
+
+func (s *ResourcesQueued) isServerEvent() {}
 
 // IRVMatchedResource represents stats for resources that are not sent by the server
 // because their version matches the `initial_resource_versions` provided in the client request.
@@ -106,3 +108,14 @@ type IRVMatchedResource struct {
 }
 
 func (s *IRVMatchedResource) isServerEvent() {}
+
+// UnknownResourceRequested indicates whether a resource that was subscribed never existed. This
+// should be rare, and can be indicative of a client-side bug.
+type UnknownResourceRequested struct {
+	// The resource's type.
+	TypeURL string
+	// The resource's name.
+	ResourceName string
+}
+
+func (s *UnknownResourceRequested) isServerEvent() {}


### PR DESCRIPTION
This relatively small change notifies the stats handler of the resources being sent by the server right as they are about to be sent, rather than every time they are queued. This allows the stats handler to compute things in bulk rather than one at a time, allowing room for improvement.