### PR TITLE
Initializing map to handle deletetion in IRV

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -335,6 +335,10 @@ func (h *handler) handleDeletionsFromIRV() {
 		if _, ok := h.entries[name]; !ok && !irv.received {
 			slog.Debug("Resource no longer exists on the server but is still present on the client. "+
 				"Explicitly marking the resource for deletion.", "resourceName", name)
+
+			if h.entries == nil {
+				h.entries = sendBufferPool.Get().(sendBuffer)
+			}
 			h.entries[name] = nil
 		}
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -429,9 +429,9 @@ func TestEndToEnd(t *testing.T) {
 		stream, cancel = newStream(t)
 		require.NoError(t, stream.Send(req))
 		waitForResponse(t, res, stream, 10*time.Millisecond)
-		require.Len(t, res.RemovedResources, 1)
-		require.Equal(t, res.RemovedResources[0], foo)
-		require.Len(t, res.Resources, 0)
+		require.ElementsMatch(t, []string{foo}, res.RemovedResources)
+		require.Empty(t, res.Resources)
+		cancel()
 	})
 
 	t.Run("SotW", func(t *testing.T) {

--- a/server_test.go
+++ b/server_test.go
@@ -418,6 +418,20 @@ func TestEndToEnd(t *testing.T) {
 			// Wait for the goroutine to die.
 			<-ch
 		}
+
+		// validate when there is no entry in cache,
+		clearEntry(foo)
+		clearEntry(qux)
+		req.InitialResourceVersions = map[string]string{
+			foo: "0",
+		}
+		req.ResourceNamesSubscribe = []string{ads.WildcardSubscription}
+		stream, cancel = newStream(t)
+		require.NoError(t, stream.Send(req))
+		waitForResponse(t, res, stream, 10*time.Millisecond)
+		require.Len(t, res.RemovedResources, 1)
+		require.Equal(t, res.RemovedResources[0], foo)
+		require.Len(t, res.Resources, 0)
 	})
 
 	t.Run("SotW", func(t *testing.T) {


### PR DESCRIPTION
when entries is nil, handleDeletionsFromIRV panic to set the deleted resources. fixing this.

## Testing:
1. `go test -v -run TestEndToEnd/delta_IRV_support -race -count=10`

2. `make && make test`

3. without the fix: tests run panic
```
go test -v -run TestEndToEnd/delta_IRV_support
=== RUN   TestEndToEnd
=== RUN   TestEndToEnd/delta_IRV_support
panic: assignment to entry in nil map

goroutine 119 [running]:
github.com/linkedin/diderot/internal/server.(*handler).handleDeletionsFromIRV(0x140001ec300)
	/Users/abharadw/sv/oss/diderot/internal/server/handlers.go:342 +0x138
github.com/linkedin/diderot/internal/server.(*handler).EndNotificationBatch(0x140001ec300)
	/Users/abharadw/sv/oss/diderot/internal/server/handlers.go:322 +0xac
github.com/linkedin/diderot/internal/server.(*deltaSubscriptionManager).ProcessSubscriptions(0x1400046bb80, 0x140007f2000)
	/Users/abharadw/sv/oss/diderot/internal/server/subscription_manager.go:146 +0x278
github.com/linkedin/diderot.(*streamHandler[...]).handleRequest(0x103b83940, 0x140007f2000)
	/Users/abharadw/sv/oss/diderot/server.go:438 +0x370
github.com/linkedin/diderot.(*streamHandler[...]).loop(0x103b83940)
	/Users/abharadw/sv/oss/diderot/server.go:396 +0xe8
github.com/linkedin/diderot.(*ADSServer).DeltaAggregatedResources(0x140001dd110, {0x103b7ccc8, 0x1400046b9d0})
	/Users/abharadw/sv/oss/diderot/server.go:283 +0x144
github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3._AggregatedDiscoveryService_DeltaAggregatedResources_Handler({0x103a66a20?, 0x140001dd110}, {0x103b7a698, 0x140004f81c0})
```