### PR TITLE
Putting back IRV changes

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -359,7 +359,7 @@ func (h *handler) handleDeletionsFromIRV() {
 			if h.entries == nil {
 				h.entries = sendBufferPool.Get().(sendBuffer)
 			}
-			h.entries[name] = nil
+			h.entries[name] = serverstats.SentResource{}
 		}
 	}
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -128,7 +128,7 @@ type handler struct {
 	// complete before the response is sent, minimizing the number of responses.
 	batchStarted bool
 
-	// initialResourceVersions is a map of resource names to their initial version.
+	// initialResourceVersions is a map of resource names to their initial versions.
 	// this informs the server of the versions of the resources the xDS client knows of.
 	initialResourceVersions map[string]*initialResourceVersion
 }
@@ -136,8 +136,8 @@ type handler struct {
 type initialResourceVersion struct {
 	// initial version of the resource, which the xDS client has seen.
 	version string
-	// received flag indicates if the resource has been received from the server and skipped from the response.
-	// we are maintaining this flag to differentiate between the resource which is deleted on cache and
+	// received flag indicates if the resource has been received from the server and skipped from the response
+	// being sent. we are maintaining this flag to differentiate between the resource which is deleted on cache and
 	// the resource which is not updated since client has last seen it.
 	received bool
 }
@@ -310,9 +310,10 @@ func (h *handler) StartNotificationBatch(initialResourceVersions map[string]stri
 	h.lock.Lock()
 	defer h.lock.Unlock()
 
-	// setInitialResourceVersion sets the initial version of resources to filter out unchanged resources.
 	if len(initialResourceVersions) > 0 {
 		h.initialResourceVersions = make(map[string]*initialResourceVersion, len(initialResourceVersions))
+
+		// setting the initial version of resources to filter out unchanged resources.
 		for name, version := range initialResourceVersions {
 			h.initialResourceVersions[name] = &initialResourceVersion{version: version}
 		}
@@ -339,7 +340,6 @@ func (h *handler) EndNotificationBatch() {
 
 	h.handleDeletionsFromIRV()
 	h.batchStarted = false
-	// resetting IRV version to nil, so that the next batch can be started with a new set of IRV.
 	h.initialResourceVersions = nil
 	if len(h.entries) > 0 {
 		h.immediateNotificationReceived.notify()
@@ -364,7 +364,7 @@ func (h *handler) handleDeletionsFromIRV() {
 	}
 }
 
-// handleMatchFromIRV checks if the given resource matches the initial resource version (IRV).
+// handleMatchFromIRV checks if the given resource matches the initial resource versions (IRV).
 func (h *handler) handleMatchFromIRV(name string, r *ads.RawResource) bool {
 	if res, ok := h.initialResourceVersions[name]; ok {
 		if r != nil && res.version == r.Version {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -339,6 +339,8 @@ func (h *handler) EndNotificationBatch() {
 
 	h.handleDeletionsFromIRV()
 	h.batchStarted = false
+	// resetting IRV version to nil, so that the next batch can be started with a new set of IRV.
+	h.initialResourceVersions = nil
 	if len(h.entries) > 0 {
 		h.immediateNotificationReceived.notify()
 		h.notificationReceived.notify()

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -340,6 +340,8 @@ func (h *handler) EndNotificationBatch() {
 
 	h.handleDeletionsFromIRV()
 	h.batchStarted = false
+	// Resetting the initial resource versions to nil, we need to make sure to handle IRV
+	// for each incoming request independently
 	h.initialResourceVersions = nil
 	if len(h.entries) > 0 {
 		h.immediateNotificationReceived.notify()
@@ -356,6 +358,8 @@ func (h *handler) handleDeletionsFromIRV() {
 			slog.Debug("Resource no longer exists on the server but is still present on the client. "+
 				"Explicitly marking the resource for deletion.", "resourceName", name)
 
+			// in some corner case, when last resource is deleted. and there is no subscribed resource present in cache,
+			// entries might be nil, so we need to allocate a new map.
 			if h.entries == nil {
 				h.entries = sendBufferPool.Get().(sendBuffer)
 			}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"log/slog"
 	"maps"
 	"sync"
 	"time"
@@ -26,7 +27,7 @@ type SendBufferSizeEstimator interface {
 // StartNotificationBatch immediately preceding it. However, SubscriptionHandler.Notify can be
 // invoked at any point.
 type BatchSubscriptionHandler interface {
-	StartNotificationBatch(int)
+	StartNotificationBatch(map[string]string, int)
 	ads.RawSubscriptionHandler
 	EndNotificationBatch()
 }
@@ -126,6 +127,19 @@ type handler struct {
 	// If batchStarted is true, Notify will not notify notificationReceived. This allows the batch to
 	// complete before the response is sent, minimizing the number of responses.
 	batchStarted bool
+
+	// initialResourceVersions is a map of resource names to their initial version.
+	// this informs the server of the versions of the resources the xDS client knows of.
+	initialResourceVersions map[string]*initialResourceVersion
+}
+
+type initialResourceVersion struct {
+	// initial version of the resource, which the xDS client has seen.
+	version string
+	// received flag indicates if the resource has been received from the server and skipped from the response.
+	// we are maintaining this flag to differentiate between the resource which is deleted on cache and
+	// the resource which is not updated since client has last seen it.
+	received bool
 }
 
 // swapEntries grabs the lock then swaps the entries map to a nil map. It resets notificationReceived
@@ -251,6 +265,10 @@ func (h *handler) Notify(name string, r *ads.RawResource, metadata ads.Subscript
 		h.entries = sendBufferPool.Get().(sendBuffer)
 	}
 
+	if h.handleMatchFromIRV(name, r) {
+		return
+	}
+
 	h.entries[name] = serverstats.SentResource{
 		Resource: r,
 		Metadata: metadata,
@@ -288,11 +306,17 @@ func (h *handler) ResourceMarshalError(name string, resource proto.Message, err 
 	}
 }
 
-func (h *handler) StartNotificationBatch(estimatedSize int) {
+func (h *handler) StartNotificationBatch(initialResourceVersions map[string]string, estimatedSize int) {
 	h.lock.Lock()
 	defer h.lock.Unlock()
 
-	if estimatedSize > 0 {
+	// setInitialResourceVersion sets the initial version of resources to filter out unchanged resources.
+	if len(initialResourceVersions) > 0 {
+		h.initialResourceVersions = make(map[string]*initialResourceVersion, len(initialResourceVersions))
+		for name, version := range initialResourceVersions {
+			h.initialResourceVersions[name] = &initialResourceVersion{version: version}
+		}
+	} else if estimatedSize > 0 {
 		// Only preallocate the send buffer if the initialResourceVersions is empty. Otherwise, it's very
 		// likely that the buffer will be underutilized and waste resources.
 		prevBuf := h.entries
@@ -313,12 +337,52 @@ func (h *handler) EndNotificationBatch() {
 	h.lock.Lock()
 	defer h.lock.Unlock()
 
+	h.handleDeletionsFromIRV()
 	h.batchStarted = false
-
 	if len(h.entries) > 0 {
 		h.immediateNotificationReceived.notify()
 		h.notificationReceived.notify()
 	}
+}
+
+// handleDeletionsFromIRV processes resources that are known to the client but are no longer present on the server.
+// This indicates that the resource has been deleted and the client is unaware of this (e.g. in a re-connect scenario)
+// The method update the entries to nil for such resources.
+func (h *handler) handleDeletionsFromIRV() {
+	for name, irv := range h.initialResourceVersions {
+		if _, ok := h.entries[name]; !ok && !irv.received {
+			slog.Debug("Resource no longer exists on the server but is still present on the client. "+
+				"Explicitly marking the resource for deletion.", "resourceName", name)
+
+			if h.entries == nil {
+				h.entries = sendBufferPool.Get().(sendBuffer)
+			}
+			h.entries[name] = nil
+		}
+	}
+}
+
+// handleMatchFromIRV checks if the given resource matches the initial resource version (IRV).
+func (h *handler) handleMatchFromIRV(name string, r *ads.RawResource) bool {
+	if res, ok := h.initialResourceVersions[name]; ok {
+		if r != nil && res.version == r.Version {
+			slog.Debug(
+				"Resource version matches with IRV from client, skipping this resource",
+				"resourceName", name,
+				"version", res.version,
+			)
+			res.received = true
+
+			if h.statsHandler != nil {
+				h.statsHandler.HandleServerEvent(h.ctx, &serverstats.IRVMatchedResource{
+					ResourceName: name,
+					Resource:     r,
+				})
+			}
+			return true
+		}
+	}
+	return false
 }
 
 func NewSotWHandler(

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -268,7 +268,7 @@ func TestHandlerBatchingWithIRV(t *testing.T) {
 		notify(bar, barResource)
 		released.Store(true)
 		handler.EndNotificationBatch()
-		require.Equal(t, sendBuffer{
+		checkSendBuffer(t, sendBuffer{
 			barResource.Name: serverstats.SentResource{Resource: barResource},
 		}, <-ch)
 	})
@@ -280,7 +280,7 @@ func TestHandlerBatchingWithIRV(t *testing.T) {
 		notify(bar, barResource)
 		released.Store(true)
 		handler.EndNotificationBatch()
-		require.Equal(t, sendBuffer{
+		checkSendBuffer(t, sendBuffer{
 			barResource.Name: serverstats.SentResource{Resource: barResource},
 			foo:              serverstats.SentResource{Resource: nil},
 		}, <-ch)
@@ -293,7 +293,7 @@ func TestHandlerBatchingWithIRV(t *testing.T) {
 		notify(bar, barResource)
 		released.Store(true)
 		handler.EndNotificationBatch()
-		require.Equal(t, sendBuffer{
+		checkSendBuffer(t, sendBuffer{
 			barResource.Name: serverstats.SentResource{Resource: barResource},
 			foo:              serverstats.SentResource{Resource: nil},
 		}, <-ch)

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -245,6 +245,7 @@ func TestHandlerBatchingWithIRV(t *testing.T) {
 	ch := make(chan sendBuffer)
 	handler := newHandler(
 		testutils.Context(t),
+		AnyTypeURL,
 		NoopLimiter{},
 		NoopLimiter{},
 		new(customStatsHandler),
@@ -267,7 +268,9 @@ func TestHandlerBatchingWithIRV(t *testing.T) {
 		notify(bar, barResource)
 		released.Store(true)
 		handler.EndNotificationBatch()
-		require.Equal(t, sendBuffer{barResource.Name: barResource}, <-ch)
+		require.Equal(t, sendBuffer{
+			barResource.Name: serverstats.SentResource{Resource: barResource},
+		}, <-ch)
 	})
 
 	t.Run("partial update, foo deleted and bar updated", func(t *testing.T) {
@@ -278,8 +281,8 @@ func TestHandlerBatchingWithIRV(t *testing.T) {
 		released.Store(true)
 		handler.EndNotificationBatch()
 		require.Equal(t, sendBuffer{
-			barResource.Name: barResource,
-			foo:              nil,
+			barResource.Name: serverstats.SentResource{Resource: barResource},
+			foo:              serverstats.SentResource{Resource: nil},
 		}, <-ch)
 	})
 
@@ -291,8 +294,8 @@ func TestHandlerBatchingWithIRV(t *testing.T) {
 		released.Store(true)
 		handler.EndNotificationBatch()
 		require.Equal(t, sendBuffer{
-			barResource.Name: barResource,
-			foo:              nil,
+			barResource.Name: serverstats.SentResource{Resource: barResource},
+			foo:              serverstats.SentResource{Resource: nil},
 		}, <-ch)
 	})
 }

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -145,7 +145,7 @@ func TestHandlerBatching(t *testing.T) {
 		expectedEntries[name] = serverstats.SentResource{Resource: nil}
 	}
 
-	h.StartNotificationBatch(0)
+	h.StartNotificationBatch(nil, 0)
 	notify()
 
 	for i := 0; i < 100; i++ {
@@ -183,7 +183,7 @@ func TestHandlerDoesNothingOnEmptyBatch(t *testing.T) {
 			return nil
 		},
 	)
-	h.StartNotificationBatch(0)
+	h.StartNotificationBatch(nil, 0)
 	h.EndNotificationBatch()
 }
 
@@ -234,4 +234,81 @@ func TestPseudoDeltaSotWHandler(t *testing.T) {
 	l.Release()
 	require.WithinDuration(t, time.Now(), start.Add(wait), 10*time.Millisecond)
 	require.ElementsMatch(t, []*anypb.Any{testutils.MustMarshal(t, bazR).Resource}, lastRes.Resources)
+}
+
+func TestHandlerBatchingWithIRV(t *testing.T) {
+	const (
+		foo = "foo"
+		bar = "bar"
+	)
+	var released atomic.Bool
+	ch := make(chan sendBuffer)
+	handler := newHandler(
+		testutils.Context(t),
+		NoopLimiter{},
+		NoopLimiter{},
+		new(customStatsHandler),
+		false,
+		func(resources sendBuffer) error {
+			ch <- maps.Clone(resources)
+			return nil
+		},
+	)
+	notify := func(name string, resource *ads.RawResource) {
+		handler.Notify(name, resource, ads.SubscriptionMetadata{})
+	}
+
+	t.Run("partial update, foo not updated and bar updated", func(t *testing.T) {
+		req := newDeltaReq([]string{"foo", "bar"}, map[string]string{"foo": "0", "bar": "0"})
+		handler.StartNotificationBatch(req.InitialResourceVersions, 0)
+		fooResource := newRawResource(foo, "0")
+		barResource := newRawResource(bar, "1")
+		notify(foo, fooResource)
+		notify(bar, barResource)
+		released.Store(true)
+		handler.EndNotificationBatch()
+		require.Equal(t, sendBuffer{barResource.Name: barResource}, <-ch)
+	})
+
+	t.Run("partial update, foo deleted and bar updated", func(t *testing.T) {
+		req := newDeltaReq([]string{foo, bar}, map[string]string{foo: "0", bar: "0"})
+		handler.StartNotificationBatch(req.InitialResourceVersions, 0)
+		barResource := newRawResource(bar, "1")
+		notify(bar, barResource)
+		released.Store(true)
+		handler.EndNotificationBatch()
+		require.Equal(t, sendBuffer{
+			barResource.Name: barResource,
+			foo:              nil,
+		}, <-ch)
+	})
+
+	t.Run("partial update, foo deleted and bar updated with wildcard subscription", func(t *testing.T) {
+		req := newDeltaReq([]string{ads.WildcardSubscription}, map[string]string{foo: "0", bar: "0"})
+		handler.StartNotificationBatch(req.InitialResourceVersions, 0)
+		barResource := newRawResource(bar, "1")
+		notify(bar, barResource)
+		released.Store(true)
+		handler.EndNotificationBatch()
+		require.Equal(t, sendBuffer{
+			barResource.Name: barResource,
+			foo:              nil,
+		}, <-ch)
+	})
+}
+
+func newDeltaReq(subscribe []string, versions map[string]string) *ads.DeltaDiscoveryRequest {
+	return &ads.DeltaDiscoveryRequest{
+		ResourceNamesSubscribe:  subscribe,
+		InitialResourceVersions: versions,
+	}
+}
+
+func newRawResource(name string, version string) *ads.RawResource {
+	return &ads.RawResource{
+		Name:     name,
+		Version:  version,
+		Resource: &anypb.Any{},
+	}
+
 }

--- a/internal/server/subscription_manager.go
+++ b/internal/server/subscription_manager.go
@@ -155,6 +155,7 @@ func (m *deltaSubscriptionManager) ProcessSubscriptions(req *ads.DeltaDiscoveryR
 func (m *sotWSubscriptionManager) ProcessSubscriptions(req *ads.SotWDiscoveryRequest) {
 	subscribe, estimatedSize := m.cleanSubscriptionsAndEstimateSize(req.ResourceNames, nil)
 
+	// sotWSubscriptionManager does not support initial resource versions, so we pass nil.
 	m.handler.StartNotificationBatch(nil, estimatedSize)
 	defer m.handler.EndNotificationBatch()
 

--- a/internal/server/subscription_manager.go
+++ b/internal/server/subscription_manager.go
@@ -123,7 +123,7 @@ func (m *deltaSubscriptionManager) ProcessSubscriptions(req *ads.DeltaDiscoveryR
 		req.ResourceNamesSubscribe, req.InitialResourceVersions,
 	)
 
-	m.handler.StartNotificationBatch(estimatedSize)
+	m.handler.StartNotificationBatch(req.InitialResourceVersions, estimatedSize)
 	defer m.handler.EndNotificationBatch()
 
 	m.lock.Lock()
@@ -155,7 +155,7 @@ func (m *deltaSubscriptionManager) ProcessSubscriptions(req *ads.DeltaDiscoveryR
 func (m *sotWSubscriptionManager) ProcessSubscriptions(req *ads.SotWDiscoveryRequest) {
 	subscribe, estimatedSize := m.cleanSubscriptionsAndEstimateSize(req.ResourceNames, nil)
 
-	m.handler.StartNotificationBatch(estimatedSize)
+	m.handler.StartNotificationBatch(nil, estimatedSize)
 	defer m.handler.EndNotificationBatch()
 
 	m.lock.Lock()

--- a/server_test.go
+++ b/server_test.go
@@ -344,6 +344,94 @@ func TestEndToEnd(t *testing.T) {
 		}, 2*time.Second, 100*time.Millisecond)
 	})
 
+	t.Run("delta IRV support", func(t *testing.T) {
+		const (
+			foo = "foo"
+			bar = "bar"
+			qux = "qux"
+		)
+
+		req := &ads.DeltaDiscoveryRequest{
+			Node:    locator.node,
+			TypeUrl: testResource.TypeURL(),
+		}
+
+		res := new(ads.DeltaDiscoveryResponse)
+
+		// Verify that using InitialResourceVersions prevents the server from resending unchanged resources upon re-subscription.
+		setCacheEntry(t, foo, "0")
+		setCacheEntry(t, bar, "1")
+		req.InitialResourceVersions = map[string]string{
+			foo: "0",
+			bar: "0",
+		}
+		req.ResourceNamesSubscribe = []string{"foo", "bar"}
+		stream, cancel := newStream(t)
+		require.NoError(t, stream.Send(req))
+		waitForResponse(t, res, stream, 10*time.Millisecond)
+		require.Len(t, res.Resources, 1)
+		require.Equal(t, res.Resources[0].Name, "bar")
+
+		// Close the stream while the cache is updated to mimic a reconnect
+		cancel()
+
+		// validating for wildcard subscriptions
+		setCacheEntry(t, foo, "0")
+		setCacheEntry(t, qux, "0")
+		bytesCache.Clear(bar, time.Now())
+		req.InitialResourceVersions = map[string]string{
+			foo: "0",
+			bar: "1",
+		}
+		req.ResourceNamesSubscribe = []string{ads.WildcardSubscription}
+		stream, cancel = newStream(t)
+		require.NoError(t, stream.Send(req))
+		waitForResponse(t, res, stream, 10*time.Millisecond)
+		require.Len(t, res.RemovedResources, 1)
+		require.Equal(t, res.RemovedResources[0], bar)
+		require.Len(t, res.Resources, 1)
+		require.Equal(t, res.Resources[0].Name, qux)
+
+		cancel()
+		// reconnect scenario
+		req.InitialResourceVersions = map[string]string{
+			foo: "0",
+			qux: "0",
+		}
+		stream, cancel = newStream(t)
+		require.NoError(t, stream.Send(req))
+		ch := make(chan error)
+		go func() {
+			ch <- stream.RecvMsg(res)
+		}()
+
+		select {
+		case <-ch:
+			t.Fatalf("unexpected response: stream does not expect any response, if no version is changed")
+		case <-time.After(1 * time.Second):
+			// It's impossible to detect when the server *doesn't* send a response, but since the timeout for
+			// receiving a response in previous parts of the test is 10ms, if the server does not send a response
+			// for a second, it's safe to say it never will.
+			cancel()
+			// Wait for the goroutine to die.
+			<-ch
+		}
+
+		// validate when there is no entry in cache,
+		clearEntry(foo)
+		clearEntry(qux)
+		req.InitialResourceVersions = map[string]string{
+			foo: "0",
+		}
+		req.ResourceNamesSubscribe = []string{ads.WildcardSubscription}
+		stream, cancel = newStream(t)
+		require.NoError(t, stream.Send(req))
+		waitForResponse(t, res, stream, 10*time.Millisecond)
+		require.ElementsMatch(t, []string{foo}, res.RemovedResources)
+		require.Empty(t, res.Resources)
+		cancel()
+	})
+
 	t.Run("SotW", func(t *testing.T) {
 		statsHandler.reset()
 
@@ -563,7 +651,7 @@ type simpleBatchHandler struct {
 	ch     atomic.Pointer[chan struct{}]
 }
 
-func (h *simpleBatchHandler) StartNotificationBatch(int) {
+func (h *simpleBatchHandler) StartNotificationBatch(map[string]string, int) {
 	ch := make(chan struct{}, 1)
 	require.True(h.t, h.ch.CompareAndSwap(nil, &ch))
 }
@@ -862,13 +950,13 @@ func TestImplicitWildcardSubscription(t *testing.T) {
 // batchFuncHandler the equivalent of funcHandler but for the BatchSubscriptionHandler interface.
 type batchFuncHandler struct {
 	t      *testing.T
-	start  func(sendBufferSize int)
+	start  func(irv map[string]string, sendBufferSize int)
 	notify func(name string, r *ads.RawResource, metadata ads.SubscriptionMetadata)
 	end    func()
 }
 
-func (b *batchFuncHandler) StartNotificationBatch(sendBufferSize int) {
-	b.start(sendBufferSize)
+func (b *batchFuncHandler) StartNotificationBatch(irv map[string]string, sendBufferSize int) {
+	b.start(irv, sendBufferSize)
 }
 
 func (b *batchFuncHandler) Notify(name string, r *ads.RawResource, metadata ads.SubscriptionMetadata) {
@@ -885,7 +973,7 @@ func (b *batchFuncHandler) EndNotificationBatch() {
 
 func NewBatchSubscriptionHandler(
 	t *testing.T,
-	start func(size int),
+	start func(versions map[string]string, size int),
 	notify func(name string, r *ads.RawResource, metadata ads.SubscriptionMetadata),
 	end func(),
 ) internal.BatchSubscriptionHandler {
@@ -900,7 +988,7 @@ func NewBatchSubscriptionHandler(
 func NewNoopBatchSubscriptionHandler(t *testing.T) internal.BatchSubscriptionHandler {
 	return NewBatchSubscriptionHandler(
 		t,
-		func(int) {},
+		func(map[string]string, int) {},
 		func(string, *ads.RawResource, ads.SubscriptionMetadata) {},
 		func() {},
 	)

--- a/server_test.go
+++ b/server_test.go
@@ -372,6 +372,17 @@ func TestEndToEnd(t *testing.T) {
 		require.Len(t, res.Resources, 1)
 		require.Equal(t, res.Resources[0].Name, "bar")
 
+		// Verify that IRV is being reset.
+		// if IRV is not reset then handler would maintain {"foo": 0, "bar": 0} from previous request on server side
+		// and when empty InitialResourceVersions being pass it would only respond with bar only .
+		// in this case it's responding with foo & bar when the request is being sent on existing stream.
+		req.InitialResourceVersions = map[string]string{}
+		req.ResourceNamesSubscribe = []string{"foo", "bar"}
+		require.NoError(t, stream.Send(req))
+		waitForResponse(t, res, stream, 10*time.Millisecond)
+		require.Len(t, res.Resources, 2)
+		require.ElementsMatch(t, []string{"foo", "bar"}, []string{res.Resources[0].Name, res.Resources[1].Name})
+
 		// Close the stream while the cache is updated to mimic a reconnect
 		cancel()
 

--- a/stats/server/server_stats.go
+++ b/stats/server/server_stats.go
@@ -109,8 +109,8 @@ type UnknownResourceRequested struct {
 
 func (s *UnknownResourceRequested) isServerEvent() {}
 
-// IRVMatchedResource represents stats for resources that are not sent by the server
-// because their version matches the `initial_resource_versions` provided in the client request.
+// IRVMatchedResource represents stats for resources that matches the `initial_resource_versions`
+// provided by the client.
 type IRVMatchedResource struct {
 	// The name of the resource
 	ResourceName string

--- a/stats/server/server_stats.go
+++ b/stats/server/server_stats.go
@@ -108,3 +108,14 @@ type UnknownResourceRequested struct {
 }
 
 func (s *UnknownResourceRequested) isServerEvent() {}
+
+// IRVMatchedResource represents stats for resources that are not sent by the server
+// because their version matches the `initial_resource_versions` provided in the client request.
+type IRVMatchedResource struct {
+	// The name of the resource
+	ResourceName string
+	// The resource itself, nil if the resource is being deleted.
+	Resource *ads.RawResource
+}
+
+func (s *IRVMatchedResource) isServerEvent() {}


### PR DESCRIPTION
it has the following changes: 
1. puts back the IRV changes reverted as part of this [PR](https://github.com/linkedin/diderot/pull/27).
2. resetting IRV version on handler after processing the batch in EndNotificationBatch.


Testting: 
1. added Tests
2. testing for resetting IRV version changes. 
without this fix: subsequent fix will maintain old IRV set. 

```
h.initialResourceVersions: map[]
initialResourceVersions: map[bar:0 foo:0]
h.initialResourceVersions: map[bar:0x140002ba660 foo:0x140002ba648]
initialResourceVersions: map[]
```

with fix: - cleans up IRV with susequnt call using the same stream. 
```
h.initialResourceVersions: map[]
initialResourceVersions: map[bar:0 foo:0]
h.initialResourceVersions: map[]
initialResourceVersions: map[]
```

