### PR TITLE
Do not print large resources

### DIFF
--- a/internal/server/handlers_delta.go
+++ b/internal/server/handlers_delta.go
@@ -165,7 +165,6 @@ func (ds *deltaSender) chunk(resourceUpdates sendBuffer) (chunks []*ads.DeltaDis
 						"maxDeltaResponseSize", ds.maxChunkSize,
 						"name", update.Name,
 						"updateSize", update.Size,
-						"resource", r,
 					)
 					continue
 				}


### PR DESCRIPTION
This was a very stupid log message. If the resource is larger than 4MB it will quickly flood the logs. The resource itself is preserved in the `serverstats.ResourceOverMaxSize` message, if the stats handler wants to log it or inspect it if it wants, but `diderot` itself should not log it.